### PR TITLE
Fix to use numactl only on numa-enabled hosts

### DIFF
--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
 	NUMA_CMD="numactl --interleave=all"
-	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
-		NUMA_CMD=
+	if ($NUMA_CMD true &>/dev/null) ; then
+		set -- $NUMA_CMD "$@"
 	fi
 
-	exec gosu mongodb $NUMA_CMD "$@"
+	exec gosu mongodb "$@"
 fi
 
 exec "$@"

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -8,9 +8,9 @@ fi
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
-	NUMA_CMD="numactl --interleave=all"
-	if ($NUMA_CMD true &>/dev/null) ; then
-		set -- $NUMA_CMD "$@"
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
 	fi
 
 	exec gosu mongodb "$@"

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -7,7 +7,13 @@ fi
 
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+
+	NUMA_CMD="numactl --interleave=all"
+	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
+		NUMA_CMD=
+	fi
+
+	exec gosu mongodb $NUMA_CMD "$@"
 fi
 
 exec "$@"

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
 	NUMA_CMD="numactl --interleave=all"
-	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
-		NUMA_CMD=
+	if ($NUMA_CMD true &>/dev/null) ; then
+		set -- $NUMA_CMD "$@"
 	fi
 
-	exec gosu mongodb $NUMA_CMD "$@"
+	exec gosu mongodb "$@"
 fi
 
 exec "$@"

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -8,9 +8,9 @@ fi
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
-	NUMA_CMD="numactl --interleave=all"
-	if ($NUMA_CMD true &>/dev/null) ; then
-		set -- $NUMA_CMD "$@"
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
 	fi
 
 	exec gosu mongodb "$@"

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -7,7 +7,13 @@ fi
 
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+
+	NUMA_CMD="numactl --interleave=all"
+	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
+		NUMA_CMD=
+	fi
+
+	exec gosu mongodb $NUMA_CMD "$@"
 fi
 
 exec "$@"

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
 	NUMA_CMD="numactl --interleave=all"
-	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
-		NUMA_CMD=
+	if ($NUMA_CMD true &>/dev/null) ; then
+		set -- $NUMA_CMD "$@"
 	fi
 
-	exec gosu mongodb $NUMA_CMD "$@"
+	exec gosu mongodb "$@"
 fi
 
 exec "$@"

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -8,9 +8,9 @@ fi
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
-	NUMA_CMD="numactl --interleave=all"
-	if ($NUMA_CMD true &>/dev/null) ; then
-		set -- $NUMA_CMD "$@"
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
 	fi
 
 	exec gosu mongodb "$@"

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -7,7 +7,13 @@ fi
 
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+
+	NUMA_CMD="numactl --interleave=all"
+	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
+		NUMA_CMD=
+	fi
+
+	exec gosu mongodb $NUMA_CMD "$@"
 fi
 
 exec "$@"

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
 	NUMA_CMD="numactl --interleave=all"
-	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
-		NUMA_CMD=
+	if ($NUMA_CMD true &>/dev/null) ; then
+		set -- $NUMA_CMD "$@"
 	fi
 
-	exec gosu mongodb $NUMA_CMD "$@"
+	exec gosu mongodb "$@"
 fi
 
 exec "$@"

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -8,9 +8,9 @@ fi
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
 
-	NUMA_CMD="numactl --interleave=all"
-	if ($NUMA_CMD true &>/dev/null) ; then
-		set -- $NUMA_CMD "$@"
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
 	fi
 
 	exec gosu mongodb "$@"

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -7,7 +7,13 @@ fi
 
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+
+	NUMA_CMD="numactl --interleave=all"
+	if ! ($NUMA_CMD true >/dev/null 2>&1) ; then
+		NUMA_CMD=
+	fi
+
+	exec gosu mongodb $NUMA_CMD "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Added check with dummy `numactl --interleave=all true` test command
to ensure that:
- kernel/host is numa-enabled,
- `--interleave=all` policy is present (I think, it should be present
  always, but didn't checked that).

Fixes #14.