### PR TITLE
Support non NUMA enabled systems

### DIFF
--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -5,9 +5,15 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- mongod "$@"
 fi
 
+CMD="numactl --interleave=all $@"
+if ! numactl --show &> /dev/null ; then
+    CMD="$@"
+    echo "Warning: no NUMA support available on this system."
+fi
+
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+	exec gosu mongodb $CMD
 fi
 
 exec "$@"

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -5,9 +5,15 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- mongod "$@"
 fi
 
+CMD="numactl --interleave=all $@"
+if ! numactl --show &> /dev/null ; then
+    CMD="$@"
+    echo "Warning: no NUMA support available on this system."
+fi
+
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+	exec gosu mongodb $CMD
 fi
 
 exec "$@"

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -5,9 +5,15 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- mongod "$@"
 fi
 
+CMD="numactl --interleave=all $@"
+if ! numactl --show &> /dev/null ; then
+    CMD="$@"
+    echo "Warning: no NUMA support available on this system."
+fi
+
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+	exec gosu mongodb $CMD
 fi
 
 exec "$@"

--- a/2.8/docker-entrypoint.sh
+++ b/2.8/docker-entrypoint.sh
@@ -5,9 +5,15 @@ if [ "${1:0:1}" = '-' ]; then
 	set -- mongod "$@"
 fi
 
+CMD="numactl --interleave=all $@"
+if ! numactl --show &> /dev/null ; then
+    CMD="$@"
+    echo "Warning: no NUMA support available on this system."
+fi
+
 if [ "$1" = 'mongod' ]; then
 	chown -R mongodb /data/db
-	exec gosu mongodb numactl --interleave=all "$@"
+	exec gosu mongodb $CMD
 fi
 
 exec "$@"


### PR DESCRIPTION
*I'm still disastrous in bash so I'm pretty sure implementation is flawed, but that's how you learn right?*

The `mongodb` image is not usable on non-NUMA systems such as boot2docker, or only using `--entrypoint=mongod` in order to bypass the `numactl` wrapping. This patch tests for NUMA availability using [`numactl --show` success](https://github.com/numactl/numactl/blob/v2.0.9/numactl.c#L135-L139).