### PR TITLE
Add version to each mongodb-org package

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -28,6 +28,10 @@ RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org=$MONGO_VERSION \
+                              mongodb-org-server=$MONGO_VERSION \
+                              mongodb-org-shell=$MONGO_VERSION \
+                              mongodb-org-mongos=$MONGO_VERSION \
+                              mongodb-org-tools=$MONGO_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mongodb \
 	&& mv /etc/mongod.conf /etc/mongod.conf.orig

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -27,11 +27,12 @@ RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR
 
 RUN set -x \
 	&& apt-get update \
-	&& apt-get install -y mongodb-org=$MONGO_VERSION \
-                              mongodb-org-server=$MONGO_VERSION \
-                              mongodb-org-shell=$MONGO_VERSION \
-                              mongodb-org-mongos=$MONGO_VERSION \
-                              mongodb-org-tools=$MONGO_VERSION \
+	&& apt-get install -y \
+		mongodb-org=$MONGO_VERSION \
+		mongodb-org-server=$MONGO_VERSION \
+		mongodb-org-shell=$MONGO_VERSION \
+		mongodb-org-mongos=$MONGO_VERSION \
+		mongodb-org-tools=$MONGO_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mongodb \
 	&& mv /etc/mongod.conf /etc/mongod.conf.orig

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -27,11 +27,12 @@ RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR
 
 RUN set -x \
 	&& apt-get update \
-	&& apt-get install -y mongodb-org-unstable=$MONGO_VERSION \
-                              mongodb-org-unstable-server=$MONGO_VERSION \
-                              mongodb-org-unstable-shell=$MONGO_VERSION \
-                              mongodb-org-unstable-mongos=$MONGO_VERSION \
-                              mongodb-org-unstable-tools=$MONGO_VERSION \
+	&& apt-get install -y \
+		mongodb-org-unstable=$MONGO_VERSION \
+		mongodb-org-unstable-server=$MONGO_VERSION \
+		mongodb-org-unstable-shell=$MONGO_VERSION \
+		mongodb-org-unstable-mongos=$MONGO_VERSION \
+		mongodb-org-unstable-tools=$MONGO_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mongodb \
 	&& mv /etc/mongod.conf /etc/mongod.conf.orig

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -28,6 +28,10 @@ RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org-unstable=$MONGO_VERSION \
+                              mongodb-org-unstable-server=$MONGO_VERSION \
+                              mongodb-org-unstable-shell=$MONGO_VERSION \
+                              mongodb-org-unstable-mongos=$MONGO_VERSION \
+                              mongodb-org-unstable-tools=$MONGO_VERSION \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mongodb \
 	&& mv /etc/mongod.conf /etc/mongod.conf.orig


### PR DESCRIPTION
[In the docs](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-debian/#install-a-specific-release-of-mongodb) you can see that if you want to install a specific version, you must list each package in the mongodb-org metapackage separately with the specified version. Otherwise, the latest version will always be installed.