### PR TITLE
postgresql-style pre-startup init scripts hook

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -27,6 +27,8 @@ RUN curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSI
 	&& tar -xvf mongo.tgz -C /usr/local --strip-components=1 \
 	&& rm mongo.tgz*
 
+RUN mkdir /docker-entrypoint-initdb.d
+
 VOLUME /data/db
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -13,6 +13,20 @@ if [ "$1" = 'mongod' ]; then
 		set -- $numa "$@"
 	fi
 
+	# internal start of server in order to allow set-up using mongo client
+	gosu mongodb mongod --fork --dbpath=/data/db --syslog
+
+	for f in /docker-entrypoint-initdb.d/*; do
+		case "$f" in
+			*.sh)  echo "$0: running $f"; . "$f" ;;
+			*.js)  echo "$0: running $f"; mongo --nodb "$f" && echo ;;
+			*)     echo "$0: ignoring $f" ;;
+		esac
+	done
+
+	# stop the temporary server daemon
+	gosu mongodb mongod --shutdown --dbpath=/data/db
+
 	exec gosu mongodb "$@"
 fi
 


### PR DESCRIPTION
Here is what I mean in issue #52 

I've just coded in the `2.6/` tree at the moment, I am seeking feedback... can add to the other versions if it's ok.

this is a direct copy of what they do in https://github.com/docker-library/postgres/

baking it into the library avoids end-users having to copy and paste the  `docker-entrypoint.sh` and override it in their own project...

instead they can add a line like

```
COPY ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d`
```

to their Dockerfile

I noticed the rest of your `docker-entrypoint.sh` is already quite similar to the postgres one so I'm hoping there's a bit of standardisation on how to achieve this kind of thing emerging in the docker-library.
