### PR TITLE
Add support for alternative data directory.

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 3AFEF01FE92B6927CC1EEC80F564179A36496327
 
 ENV MONGO_VERSION 2.2.7
+ENV DATADIR /data/db
 
 RUN curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz" -o mongo.tgz \
 	&& curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz.sig" -o mongo.tgz.sig \

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mongod' ]; then
-	chown -R mongodb /data/db
+	chown -R mongodb "$DATADIR"
 
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys CEA1E18DDA77EF4E67884FF2A6982D0160456C5A
 
 ENV MONGO_VERSION 2.4.14
+ENV DATADIR /data/db
 
 RUN curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz" -o mongo.tgz \
 	&& curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz.sig" -o mongo.tgz.sig \

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mongod' ]; then
-	chown -R mongodb /data/db
+	chown -R mongodb "$DATADIR"
 
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DFFA3DCF326E302C4787673A01C4E7FAAAB2461C
 
 ENV MONGO_VERSION 2.6.11
+ENV DATADIR /data/db
 
 RUN curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz" -o mongo.tgz \
 	&& curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz.sig" -o mongo.tgz.sig \

--- a/2.6/docker-entrypoint.sh
+++ b/2.6/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mongod' ]; then
-	chown -R mongodb /data/db
+	chown -R mongodb "$DATADIR"
 
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 492EAFE8CD016
 
 ENV MONGO_MAJOR 3.0
 ENV MONGO_VERSION 3.0.6
+ENV DATADIR /data/db
 
 RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
 

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mongod' ]; then
-	chown -R mongodb /data/db
+	chown -R mongodb "$DATADIR"
 
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 13ACB91D285DD
 
 ENV MONGO_MAJOR 3.1
 ENV MONGO_VERSION 3.1.9
+ENV DATADIR /data/db
 
 RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
 

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mongod' ]; then
-	chown -R mongodb /data/db
+	chown -R mongodb "$DATADIR"
 
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then


### PR DESCRIPTION
This follows the convention in:
                                                                                                                                                                             
* [MySQL](https://github.com/docker-library/mysql/blob/master/5.6/docker-entrypoint.sh#L98)
* [Postgres](https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh#L11)

Helps a lot provisioning the container with an alternative volume path - if needed. Keeps backwards compatibility by defining the environment variable in the Dockerfile.