### PR TITLE
Alpine variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: bash
 services: docker
 
 env:
-  - VERSION=3.2
-  - VERSION=3.1
-  - VERSION=3.0
-  - VERSION=2.6
-  - VERSION=2.4
-  - VERSION=2.2
+  - VERSION=3.2 VARIANT=
+  - VERSION=3.2 VARIANT=alpine
+  - VERSION=3.1 VARIANT=
+  - VERSION=3.0 VARIANT=
+  - VERSION=2.6 VARIANT=
+  - VERSION=2.6 VARIANT=alpine
+  - VERSION=2.4 VARIANT=
+  - VERSION=2.2 VARIANT=
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
@@ -15,10 +17,10 @@ install:
 before_script:
   - env | sort
   - cd "$VERSION"
-  - image="mongo:$VERSION"
+  - image="mongo:$VERSION${VARIANT:+-$VARIANT}"
 
 script:
-  - docker build -t "$image" .
+  - docker build -t "$image" "${VARIANT:-.}"
   - ~/official-images/test/run.sh "$image"
 
 after_script:

--- a/2.6/alpine/Dockerfile
+++ b/2.6/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
 	&& chmod +x /usr/local/bin/gosu \
 	&& curl -SL "https://github.com/mongodb/mongo/archive/r$MONGO_VERSION.tar.gz" -o mongo.tgz \
 	&& mkdir mongo \
-	&& tar -xvf mongo.tgz -C mongo --strip-components=1 \
+	&& tar -xf mongo.tgz -C mongo --strip-components=1 \
 	&& cd mongo \
 	&& scons -j$(getconf _NPROCESSORS_ONLN) \
 	&& scons --prefix=/opt/mongo install \

--- a/2.6/alpine/Dockerfile
+++ b/2.6/alpine/Dockerfile
@@ -8,12 +8,14 @@ RUN adduser -D mongodb
 RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
 	# grab gosu for easy step-down from root
 	&& curl -o /usr/local/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
-	&& chmod +x /usr/local/bin/gosu \
-	&& curl -SL "https://github.com/mongodb/mongo/archive/r$MONGO_VERSION.tar.gz" -o mongo.tgz \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz" -o mongo.tgz \
 	&& mkdir mongo \
-	&& tar -xf mongo.tgz -C mongo --strip-components=1 \
-	&& cd mongo \
-	&& scons -j$(getconf _NPROCESSORS_ONLN) \
+	&& tar -xf mongo.tgz -C mongo --strip-components=1
+
+RUN cd mongo \
+	&& scons -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors \
 	&& scons --prefix=/opt/mongo install \
 	&& rm mongo.tgz \
 	&& apk del .build-deps

--- a/2.6/alpine/Dockerfile
+++ b/2.6/alpine/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.3
+
+ENV MONGO_VERSION 2.6.11
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN adduser -D mongodb
+
+RUN apk add --no-cache --virtual .build-deps curl tar \
+    # grab gosu for easy step-down from root
+    && curl -o /usr/local/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
+    && chmod +x /usr/local/bin/gosu \
+    && curl -SL "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGO_VERSION.tgz" -o mongo.tgz \
+	&& tar -xvf mongo.tgz -C /usr/local --strip-components=1 \
+	&& rm mongo.tgz \
+	&& apk del .build-deps
+
+VOLUME /data/db
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/2.6/alpine/Dockerfile
+++ b/2.6/alpine/Dockerfile
@@ -5,7 +5,8 @@ ENV MONGO_VERSION 2.6.11
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN adduser -D mongodb
 
-RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
+RUN apk add --no-cache --virtual .deps openssl \
+	&& apk add --no-cache --virtual .build-deps curl tar scons g++ linux-headers openssl-dev \
 	# grab gosu for easy step-down from root
 	&& curl -o /usr/local/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
 	&& chmod +x /usr/local/bin/gosu
@@ -15,7 +16,7 @@ RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz"
 	&& tar -xf mongo.tgz -C mongo --strip-components=1
 
 RUN cd mongo \
-	&& scons -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors \
+	&& scons core --ssl -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors \
 	&& scons --prefix=/opt/mongo install \
 	&& rm mongo.tgz \
 	&& apk del .build-deps

--- a/2.6/alpine/docker-entrypoint.sh
+++ b/2.6/alpine/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+if [ "$1" = 'mongod' ]; then
+	chown -R mongodb /data/db
+
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+
+	exec gosu mongodb "$@"
+fi
+
+exec "$@"

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -6,19 +6,27 @@ ENV MONGO_VERSION 3.2.1
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN adduser -D mongodb
 
-RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
+RUN apk add --no-cache --virtual .deps openssl \
+	&& apk add --no-cache --virtual .build-deps curl tar scons g++ openssl-dev \
 	# grab gosu for easy step-down from root
 	&& curl -o /usr/local/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
 	&& chmod +x /usr/local/bin/gosu
 
-RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz" -o mongo.tgz \
+RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz" -o mongo.tar.gz \
 	&& mkdir mongo \
-	&& tar -xf mongo.tgz -C mongo --strip-components=1
+	&& tar -xf mongo.tar.gz -C mongo --strip-components=1 \
+	&& rm mongo.tar.gz
 
 RUN cd mongo \
-	&& scons -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors  \
+	&& wget  \
+	    http://git.alpinelinux.org/cgit/aports/plain/testing/mongodb/40-fix-elf-native-class.patch \
+	    https://patch-diff.githubusercontent.com/raw/mongodb/mongo/pull/1059.patch \
+	&& patch -p1 < 40-fix-elf-native-class.patch \
+	&& patch -p1 < 1059.patch \
+	&& scons core -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors  \
 	&& scons --prefix=/opt/mongo install \
-	&& rm mongo.tgz \
+	&& cd .. \
+	&& rm -r mongo \
 	&& apk del .build-deps
 
 VOLUME /data/db

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
 	&& chmod +x /usr/local/bin/gosu \
 	&& curl -SL "https://github.com/mongodb/mongo/archive/r$MONGO_VERSION.tar.gz" -o mongo.tgz \
 	&& mkdir mongo \
-	&& tar -xvf mongo.tgz -C mongo --strip-components=1 \
+	&& tar -xf mongo.tgz -C mongo --strip-components=1 \
 	&& cd mongo \
 	&& scons -j$(getconf _NPROCESSORS_ONLN) \
 	&& scons --prefix=/opt/mongo install \

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -9,12 +9,14 @@ RUN adduser -D mongodb
 RUN apk add --no-cache --virtual .build-deps curl tar scons g++ \
 	# grab gosu for easy step-down from root
 	&& curl -o /usr/local/bin/gosu -fsSL "https://github.com/tianon/gosu/releases/download/1.7/gosu-amd64" \
-	&& chmod +x /usr/local/bin/gosu \
-	&& curl -SL "https://github.com/mongodb/mongo/archive/r$MONGO_VERSION.tar.gz" -o mongo.tgz \
+	&& chmod +x /usr/local/bin/gosu
+
+RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz" -o mongo.tgz \
 	&& mkdir mongo \
-	&& tar -xf mongo.tgz -C mongo --strip-components=1 \
-	&& cd mongo \
-	&& scons -j$(getconf _NPROCESSORS_ONLN) \
+	&& tar -xf mongo.tgz -C mongo --strip-components=1
+
+RUN cd mongo \
+	&& scons -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors  \
 	&& scons --prefix=/opt/mongo install \
 	&& rm mongo.tgz \
 	&& apk del .build-deps

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.3
 
-ENV MONGO_VERSION 2.6.11
+ENV MONGO_MAJOR 3.2
+ENV MONGO_VERSION 3.2.1
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN adduser -D mongodb

--- a/3.2/alpine/Dockerfile
+++ b/3.2/alpine/Dockerfile
@@ -18,12 +18,12 @@ RUN curl -SL "https://fastdl.mongodb.org/src/mongodb-src-r$MONGO_VERSION.tar.gz"
 	&& rm mongo.tar.gz
 
 RUN cd mongo \
-	&& wget  \
+	&& wget \
 	    http://git.alpinelinux.org/cgit/aports/plain/testing/mongodb/40-fix-elf-native-class.patch \
 	    https://patch-diff.githubusercontent.com/raw/mongodb/mongo/pull/1059.patch \
 	&& patch -p1 < 40-fix-elf-native-class.patch \
 	&& patch -p1 < 1059.patch \
-	&& scons core -j$(getconf _NPROCESSORS_ONLN) --disable-warnings-as-errors  \
+	&& scons core -j$(getconf _NPROCESSORS_ONLN) --ssl --disable-warnings-as-errors  \
 	&& scons --prefix=/opt/mongo install \
 	&& cd .. \
 	&& rm -r mongo \

--- a/3.2/alpine/docker-entrypoint.sh
+++ b/3.2/alpine/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+if [ "$1" = 'mongod' ]; then
+	chown -R mongodb /data/db
+
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+
+	exec gosu mongodb "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
```
$ docker images | grep mongo
mongo                   2.6-alpine          a1495b342a81        4 seconds ago        300 MB
mongo                   2.6                 f1bcb0ba4c53        2 minutes ago        392.8 MB
```

Not a such difference. I'm quite surprised because Alpine mongodb package took only ~60MB of space: https://pkgs.alpinelinux.org/package/testing/x86_64/mongodb

Maybe try be compiling [from source](https://docs.mongodb.org/manual/contributors/tutorial/build-mongodb-from-source/)?

Update: Alpine integration of mongo:
- mongodb/mongo#1060
- https://github.com/mongodb/mongo/pull/1061

First of all, are you interested for an Alpine variant?
