### PR TITLE
Update to 3.2.7

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex \
 	done
 
 ENV MONGO_MAJOR 3.2
-ENV MONGO_VERSION 3.2.6
+ENV MONGO_VERSION 3.2.7
 
 RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
 


### PR DESCRIPTION
```
Step 11 : RUN set -x 	&& apt-get update 	&& apt-get install -y 		mongodb-org=$MONGO_VERSION 		mongodb-org-server=$MONGO_VERSION 	mongodb-org-shell=$MONGO_VERSION 		mongodb-org-mongos=$MONGO_VERSION 		mongodb-org-tools=$MONGO_VERSION 	&& rm -rf /var/lib/apt/lists/* 	&& rm -rf /var/lib/mongodb 	&& mv /etc/mongod.conf /etc/mongod.conf.orig
 ---> Running in 3e1a4ce4ae64
+ apt-get update
Get:1 http://security.debian.org wheezy/updates Release.gpg [1554 B]
Get:2 http://repo.mongodb.org wheezy/mongodb-org/3.2 Release.gpg [801 B]
Get:3 http://security.debian.org wheezy/updates Release [39.0 kB]
Get:4 http://security.debian.org wheezy/updates/main amd64 Packages [467 kB]
Get:5 http://repo.mongodb.org wheezy/mongodb-org/3.2 Release [2940 B]
Get:6 http://httpredir.debian.org wheezy Release.gpg [2373 B]
Get:7 http://repo.mongodb.org wheezy/mongodb-org/3.2/main amd64 Packages [6622 B]
Get:8 http://httpredir.debian.org wheezy-updates Release.gpg [1554 B]
Get:9 http://httpredir.debian.org wheezy Release [191 kB]
Get:10 http://httpredir.debian.org wheezy-updates Release [151 kB]
Get:11 http://httpredir.debian.org wheezy/main amd64 Packages [7634 kB]
Get:12 http://httpredir.debian.org wheezy-updates/main amd64 Packages [7481 B]
Fetched 8506 kB in 2s (3027 kB/s)
Reading package lists...
+ apt-get install -y mongodb-org=3.2.7 mongodb-org-server=3.2.7 mongodb-org-shell=3.2.7 mongodb-org-mongos=3.2.7 mongodb-org-tools=3.2.7
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 mongodb-org-mongos : Depends: libc6 (>= 2.14) but 2.13-38+deb7u10 is to be installed
 mongodb-org-server : Depends: libc6 (>= 2.14) but 2.13-38+deb7u10 is to be installed
 mongodb-org-shell : Depends: libc6 (>= 2.14) but 2.13-38+deb7u10 is to be installed
 mongodb-org-tools : Depends: libc6 (>= 2.14) but 2.13-38+deb7u10 is to be installed
E: Unable to correct problems, you have held broken packages.
Removing intermediate container 3e1a4ce4ae64
The command '/bin/sh -c set -x 	&& apt-get update 	&& apt-get install -y 	mongodb-org=$MONGO_VERSION 		mongodb-org-server=$MONGO_VERSION 	mongodb-org-shell=$MONGO_VERSION 		mongodb-org-mongos=$MONGO_VERSION 		mongodb-org-tools=$MONGO_VERSION 	&& rm -rf /var/lib/apt/lists/* 	&& rm -rf /var/lib/mongodb 	&& mv /etc/mongod.conf /etc/mongod.conf.orig' returned a non-zero code: 100
```

For 3.3, we fixed this by switching to `jessie`, which is supported in upstream's repos, but only for 3.3 (see http://repo.mongodb.org/apt/debian/dists/jessie/mongodb-org/); https://github.com/docker-library/mongo/commit/61925116dacc2767367a09c749d905110e17a0c8.

cc #46