### PR TITLE
Add new "windowsservercore" variants

### DIFF
--- a/3.0/windows/windowsservercore/Dockerfile
+++ b/3.0/windows/windowsservercore/Dockerfile
@@ -1,0 +1,48 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV MONGO_VERSION 3.0.12
+ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
+ENV MONGO_DOWNLOAD_SHA256 be537b5fdc1763bb8640ac6384a44fa787c12499cfa648338c0695c5752de18a
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+	if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=all' \
+		); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/3.2/windows/windowsservercore/Dockerfile
+++ b/3.2/windows/windowsservercore/Dockerfile
@@ -1,0 +1,48 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV MONGO_VERSION 3.2.9
+ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
+ENV MONGO_DOWNLOAD_SHA256 348db5060e5c821acbd170331e806ea0233626837e6ea30e7d0e8dc72cc2e41f
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+	if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=all' \
+		); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/3.3/windows/windowsservercore/Dockerfile
+++ b/3.3/windows/windowsservercore/Dockerfile
@@ -1,0 +1,48 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV MONGO_VERSION 3.3.11
+ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
+ENV MONGO_DOWNLOAD_SHA256 cea09e54b6540bfd4f6c55a058f81d96a543557eb023289cad36d577424bd079
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+	if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=all' \
+		); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -70,4 +70,26 @@ for version in "${versions[@]}"; do
 		GitCommit: $commit
 		Directory: $version
 	EOE
+
+	for v in \
+		windows/windowsservercore windows/nanoserver \
+	; do
+		dir="$version/$v"
+		variant="$(basename "$v")"
+
+		[ -f "$dir/Dockerfile" ] || continue
+
+		commit="$(dirCommit "$dir")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
+		echo
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $dir
+		EOE
+		[ "$variant" = "$v" ] || echo "Constraints: $variant"
+	done
 done


### PR DESCRIPTION
This intentionally does not include 2.6 since there is not an official MSI release for the 2.6 series and I didn't think it was worth the effort to create a custom zip-based `Dockerfile` just for 2.6.

I used the MSIs instead of upstream's zip files for three main reasons:

1. signatures verified by built-in Windows tooling (no need to install something like "gpg4win" just to verify a signature)
2. upstream's official "Windows Install" docs use the MSI (and give helpful hints for unattended install)
3. using the zip files directly left us missing at least one DLL I didn't feel it was worthwhile to track down :smile: