### PR TITLE
Update 3.2 to jessie

### DIFF
--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
@@ -41,7 +41,7 @@ RUN set -ex \
 ENV MONGO_MAJOR 3.2
 ENV MONGO_VERSION 3.2.9
 
-RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
 
 RUN set -x \
 	&& apt-get update \

--- a/update.sh
+++ b/update.sh
@@ -22,8 +22,11 @@ for version in "${versions[@]}"; do
 		major='testing'
 	fi
 
+	from="$(awk -F '[[:space:]]+' 'toupper($1) == "FROM" { print $2; exit }' "$version/Dockerfile")" # "debian:xxx"
+	suite="${from#*:}" # "wheezy" or "jessie"
+
 	if [ "${version%%.*}" -ge 3 ]; then
-		packagesUrl="http://repo.mongodb.org/apt/debian/dists/wheezy/mongodb-org/$major/main/binary-amd64/Packages"
+		packagesUrl="http://repo.mongodb.org/apt/debian/dists/$suite/mongodb-org/$major/main/binary-amd64/Packages"
 	else
 		packagesUrl='http://downloads-distro.mongodb.org/repo/debian-sysvinit/dists/dist/10gen/binary-amd64/Packages'
 	fi


### PR DESCRIPTION
Closes #46

This matches what we did with 3.3 in https://github.com/docker-library/mongo/commit/61925116dacc2767367a09c749d905110e17a0c8. :+1: