### PR TITLE
Reduce windowsservercore image size

### DIFF
--- a/3.0/windows/windowsservercore/Dockerfile
+++ b/3.0/windows/windowsservercore/Dockerfile
@@ -2,10 +2,6 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-# PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
-# doing this first to share cache across versions more aggressively
-
 ENV MONGO_VERSION 3.0.14
 ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
 ENV MONGO_DOWNLOAD_SHA256 5a081722c42c79f23d9201c97500be6ddc8741b66ce707d88dad058bf84165f1
@@ -30,12 +26,16 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 			'INSTALLLOCATION=C:\mongodb', \
 			'ADDLOCAL=all' \
 		); \
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongo --version'; mongo --version; \
 	Write-Host '  mongod --version'; mongod --version; \
 	\
 	Write-Host 'Removing ...'; \
+	Remove-Item C:\mongodb\bin\*.pdb -Force; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
 	Remove-Item mongo.msi -Force; \
 	\
 	Write-Host 'Complete.';

--- a/3.2/windows/windowsservercore/Dockerfile
+++ b/3.2/windows/windowsservercore/Dockerfile
@@ -2,10 +2,6 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-# PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
-# doing this first to share cache across versions more aggressively
-
 ENV MONGO_VERSION 3.2.10
 ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
 ENV MONGO_DOWNLOAD_SHA256 630b614df367d8ca98f7d57e3937cae7c3915e1fb8da100f316c680da8d7f4ef
@@ -30,12 +26,16 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 			'INSTALLLOCATION=C:\mongodb', \
 			'ADDLOCAL=all' \
 		); \
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongo --version'; mongo --version; \
 	Write-Host '  mongod --version'; mongod --version; \
 	\
 	Write-Host 'Removing ...'; \
+	Remove-Item C:\mongodb\bin\*.pdb -Force; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
 	Remove-Item mongo.msi -Force; \
 	\
 	Write-Host 'Complete.';

--- a/3.3/windows/windowsservercore/Dockerfile
+++ b/3.3/windows/windowsservercore/Dockerfile
@@ -2,10 +2,6 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-# PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
-# doing this first to share cache across versions more aggressively
-
 ENV MONGO_VERSION 3.3.15
 ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
 ENV MONGO_DOWNLOAD_SHA256 2b816461c55d8e45e159be1343f603a551ca1b0c468f30028c6fa25d2308e5eb
@@ -30,12 +26,16 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 			'INSTALLLOCATION=C:\mongodb', \
 			'ADDLOCAL=all' \
 		); \
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongo --version'; mongo --version; \
 	Write-Host '  mongod --version'; mongod --version; \
 	\
 	Write-Host 'Removing ...'; \
+	Remove-Item C:\mongodb\bin\*.pdb -Force; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
 	Remove-Item mongo.msi -Force; \
 	\
 	Write-Host 'Complete.';

--- a/3.4-rc/windows/windowsservercore/Dockerfile
+++ b/3.4-rc/windows/windowsservercore/Dockerfile
@@ -2,10 +2,6 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-# PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', 'C:\mongodb\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
-# doing this first to share cache across versions more aggressively
-
 ENV MONGO_VERSION 3.4.0-rc2
 ENV MONGO_DOWNLOAD_URL http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-${MONGO_VERSION}-signed.msi
 ENV MONGO_DOWNLOAD_SHA256 f378e3f3e31ebf6529f18a0cf22e33d61bf9ed7d73abf5e54e35d23d7a30c46a
@@ -30,12 +26,16 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 			'INSTALLLOCATION=C:\mongodb', \
 			'ADDLOCAL=all' \
 		); \
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongo --version'; mongo --version; \
 	Write-Host '  mongod --version'; mongod --version; \
 	\
 	Write-Host 'Removing ...'; \
+	Remove-Item C:\mongodb\bin\*.pdb -Force; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
 	Remove-Item mongo.msi -Force; \
 	\
 	Write-Host 'Complete.';


### PR DESCRIPTION
This changes reduce the mongo image size for all windowsservercore images.

* Remove second RUN command to set the PATH, saves about 30-50 MB
* Remove all *.pdb files in mongodb\bin folder, saves about 240 MB
* Remove the MSI from install cache, saves about 100 MB

I did some research back in February commented in https://github.com/StefanScherer/dockerfiles-windows/issues/1 where you can find more details.