### PR TITLE
[3.0] Use debian jessie to prevent segfault with wheezy

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb


### PR DESCRIPTION
Hi, I was trying to build this Dockerfile of 3.0 but got a segfault on Step 2 (`RUN groupadd -r mongodb && useradd -r -g mongodb mongodb`) with docker 1.12.5, on a debian 8.6 host.

Upgrading the Dockerfile to use `debian:jessie` prevents this error (at least for me).