### PR TITLE
Use "/etc/apt/trusted.gpg.d" instead of "apt-key adv"

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -22,8 +22,17 @@ RUN set -x \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
 
+ENV GPG_KEYS \
 # gpg: key 7F0CEB10: public key "Richard Kreuter <richard@10gen.com>" imported
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10
+	492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 ENV MONGO_MAJOR 3.0
 ENV MONGO_VERSION 3.0.14

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -22,21 +22,23 @@ RUN set -x \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
 
+ENV GPG_KEYS \
 # pub   4096R/AAB2461C 2014-02-25 [expires: 2016-02-25]
 #       Key fingerprint = DFFA 3DCF 326E 302C 4787  673A 01C4 E7FA AAB2 461C
 # uid                  MongoDB 2.6 Release Signing Key <packaging@mongodb.com>
-#
+	DFFA3DCF326E302C4787673A01C4E7FAAAB2461C \
 # pub   4096R/EA312927 2015-10-09 [expires: 2017-10-08]
 #       Key fingerprint = 42F3 E95A 2C4F 0827 9C49  60AD D68F A50F EA31 2927
 # uid                  MongoDB 3.2 Release Signing Key <packaging@mongodb.com>
-#
-ENV GPG_KEYS \
-	DFFA3DCF326E302C4787673A01C4E7FAAAB2461C \
 	42F3E95A2C4F08279C4960ADD68FA50FEA312927
-RUN set -ex \
-	&& for key in $GPG_KEYS; do \
-		apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 ENV MONGO_MAJOR 3.2
 ENV MONGO_VERSION 3.2.11

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -22,10 +22,19 @@ RUN set -x \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
 
+ENV GPG_KEYS \
 # pub   4096R/A15703C6 2016-01-11 [expires: 2018-01-10]
 #       Key fingerprint = 0C49 F373 0359 A145 1858  5931 BC71 1F9B A157 03C6
 # uid                  MongoDB 3.4 Release Signing Key <packaging@mongodb.com>
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6
+	0C49F3730359A14518585931BC711F9BA15703C6
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
 ENV MONGO_MAJOR 3.4
 ENV MONGO_VERSION 3.4.1


### PR DESCRIPTION
> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a
> descriptive name and either "gpg" or "asc" as file extension.

https://manpages.debian.org/cgi-bin/man.cgi?query=apt-key&manpath=Debian+testing+stretch

See also https://github.com/docker-library/cassandra/pull/91 and https://github.com/docker-library/mariadb/pull/93.