### PR TITLE
mongos is also valid target for stepping down and numactl

### DIFF
--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -6,12 +6,17 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'mongod' -a "$(id -u)" = '0' ]; then
-	chown -R mongodb /data/configdb /data/db
+# all mongo* commands should be dropped to the correct user
+if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'mongod' ]; then
+		chown -R mongodb /data/configdb /data/db
+	fi
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
-if [ "$1" = 'mongod' ]; then
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$1" == mongo* ]]; then
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -6,12 +6,17 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'mongod' -a "$(id -u)" = '0' ]; then
-	chown -R mongodb /data/configdb /data/db
+# all mongo* commands should be dropped to the correct user
+if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'mongod' ]; then
+		chown -R mongodb /data/configdb /data/db
+	fi
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
-if [ "$1" = 'mongod' ]; then
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$1" == mongo* ]]; then
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -6,12 +6,17 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'mongod' -a "$(id -u)" = '0' ]; then
-	chown -R mongodb /data/configdb /data/db
+# all mongo* commands should be dropped to the correct user
+if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'mongod' ]; then
+		chown -R mongodb /data/configdb /data/db
+	fi
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
-if [ "$1" = 'mongod' ]; then
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$1" == mongo* ]]; then
 	numa='numactl --interleave=all'
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"


### PR DESCRIPTION
Fixes #137

`numctl` is necessary for `mongos`.
> you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
> \- [docs](https://docs.mongodb.com/manual/administration/production-notes/#mongodb-and-numa-hardware)

Maybe we should also add `numctl` when they do `mongo` for the client or even `mongodump` and friends?

```console
$ # [[ "$1" == mongo* ]] would match these ones:
mongo         mongodump     mongofiles    mongooplog    mongorestore  mongostat
mongod        mongoexport   mongoimport   mongoperf     mongos        mongotop
```

Should we also `chown` and `gosu mongodb` on all of them as well?