### PR TITLE
feat(HEALTHCHECK): add healthcheck instruction in Dockerfile to check mongo status

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -59,5 +59,7 @@ VOLUME /data/db /data/configdb
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD echo 'db.stats().ok' | mongo --quiet || exit1
+
 EXPOSE 27017
 CMD ["mongod"]

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -65,5 +65,7 @@ VOLUME /data/db /data/configdb
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD echo 'db.stats().ok' | mongo --quiet || exit1
+
 EXPOSE 27017
 CMD ["mongod"]

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -61,5 +61,7 @@ VOLUME /data/db /data/configdb
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=3 CMD echo 'db.stats().ok' | mongo --quiet || exit1
+
 EXPOSE 27017
 CMD ["mongod"]


### PR DESCRIPTION
Hey, 

Even if everyone knows that mongo is so strong to be unhealth, this feature could be useful.
Maybe there is a best way to check mongo status and/or interval and timeout values could be adjusted but anyway, that's a first try.

  * Could be related to https://github.com/docker-library/mongo/issues/105 

Have fun