### PR TITLE
Add "docker-entrypoint-initdb.d" behavior which mimics PostgreSQL, including (optional) automated "root" user creation

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,10 +1,14 @@
-FROM debian:wheezy
+FROM debian:wheezy-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
+# add "wheezy-backports" for "jq"
+RUN echo 'deb http://deb.debian.org/debian wheezy-backports main' > /etc/apt/sources.list.d/backports.list
+
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +25,8 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 ENV GPG_KEYS \
 # gpg: key 7F0CEB10: public key "Richard Kreuter <richard@10gen.com>" imported
@@ -56,8 +62,9 @@ RUN mkdir -p /data/db /data/configdb \
 	&& chown -R mongodb:mongodb /data/db /data/configdb
 VOLUME /data/db /data/configdb
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017
 CMD ["mongod"]

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -11,6 +11,7 @@ if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'mongod' ]; then
 		chown -R mongodb /data/configdb /data/db
 	fi
+	chown --dereference mongodb /dev/stdout /dev/stderr
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
@@ -21,6 +22,104 @@ if [[ "$1" == mongo* ]]; then
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"
 	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [ "$1" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		set -- "$@" --auth
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	definitelyAlreadyInitialized=
+	for path in \
+		/data/db/WiredTiger \
+		/data/db/journal \
+		/data/db/local.0 \
+		/data/db/storage.bson \
+	; do
+		if [ -e "$path" ]; then
+			definitelyAlreadyInitialized="$path"
+			break
+		fi
+	done
+
+	if [ -z "$definitelyAlreadyInitialized" ]; then
+		"$@" --fork --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1"
+
+		mongo=( mongo --quiet )
+
+		# check to see that "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, etc)
+		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+			echo >&2
+			echo >&2 'error: mongod does not appear to have started up -- perhaps it had an error?'
+			echo >&2
+			exit 1
+		fi
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(jq --arg 'user' "$MONGO_INITDB_ROOT_USERNAME" --null-input '$user'),
+					pwd: $(jq --arg 'pwd' "$MONGO_INITDB_ROOT_PASSWORD" --null-input '$pwd'),
+					roles: [ { role: 'root', db: $(jq --arg 'db' "$rootAuthDatabase" --null-input '$db') } ]
+				})
+			EOJS
+
+			mongo+=(
+				--username="$MONGO_INITDB_ROOT_USERNAME"
+				--password="$MONGO_INITDB_ROOT_PASSWORD"
+				--authenticationDatabase="$rootAuthDatabase"
+			)
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"$@" --shutdown
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	unset MONGO_INITDB_ROOT_USERNAME
+	unset MONGO_INITDB_ROOT_PASSWORD
+	unset MONGO_INITDB_DATABASE
 fi
 
 exec "$@"

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +22,8 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 ENV GPG_KEYS \
 # pub   4096R/AAB2461C 2014-02-25 [expires: 2016-02-25]
@@ -62,8 +65,9 @@ RUN mkdir -p /data/db /data/configdb \
 	&& chown -R mongodb:mongodb /data/db /data/configdb
 VOLUME /data/db /data/configdb
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017
 CMD ["mongod"]

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -11,6 +11,7 @@ if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'mongod' ]; then
 		chown -R mongodb /data/configdb /data/db
 	fi
+	chown --dereference mongodb /dev/stdout /dev/stderr
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
@@ -21,6 +22,109 @@ if [[ "$1" == mongo* ]]; then
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"
 	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [ "$1" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		set -- "$@" --auth
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	definitelyAlreadyInitialized=
+	for path in \
+		/data/db/WiredTiger \
+		/data/db/journal \
+		/data/db/local.0 \
+		/data/db/storage.bson \
+	; do
+		if [ -e "$path" ]; then
+			definitelyAlreadyInitialized="$path"
+			break
+		fi
+	done
+
+	if [ -z "$definitelyAlreadyInitialized" ]; then
+		"$@" --fork --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1"
+
+		mongo=( mongo --quiet )
+
+		# check to see that "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, etc)
+		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+			# TODO figure out why only MongoDB 3.2 seems to exit from "--fork" before it's actually listening
+			# (adding "sleep 0.01" was sufficient on Tianon's local box, hence this tiny "retry up to one time")
+			sleep 5
+		fi
+		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+			echo >&2
+			echo >&2 'error: mongod does not appear to have started up -- perhaps it had an error?'
+			echo >&2
+			exit 1
+		fi
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(jq --arg 'user' "$MONGO_INITDB_ROOT_USERNAME" --null-input '$user'),
+					pwd: $(jq --arg 'pwd' "$MONGO_INITDB_ROOT_PASSWORD" --null-input '$pwd'),
+					roles: [ { role: 'root', db: $(jq --arg 'db' "$rootAuthDatabase" --null-input '$db') } ]
+				})
+			EOJS
+
+			mongo+=(
+				--username="$MONGO_INITDB_ROOT_USERNAME"
+				--password="$MONGO_INITDB_ROOT_PASSWORD"
+				--authenticationDatabase="$rootAuthDatabase"
+			)
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"$@" --shutdown
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	unset MONGO_INITDB_ROOT_USERNAME
+	unset MONGO_INITDB_ROOT_PASSWORD
+	unset MONGO_INITDB_DATABASE
 fi
 
 exec "$@"

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +22,8 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
+
+RUN mkdir /docker-entrypoint-initdb.d
 
 ENV GPG_KEYS \
 # pub   4096R/A15703C6 2016-01-11 [expires: 2018-01-10]
@@ -58,8 +61,9 @@ RUN mkdir -p /data/db /data/configdb \
 	&& chown -R mongodb:mongodb /data/db /data/configdb
 VOLUME /data/db /data/configdb
 
-COPY docker-entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017
 CMD ["mongod"]

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -11,6 +11,7 @@ if [[ "$1" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'mongod' ]; then
 		chown -R mongodb /data/configdb /data/db
 	fi
+	chown --dereference mongodb /dev/stdout /dev/stderr
 	exec gosu mongodb "$BASH_SOURCE" "$@"
 fi
 
@@ -21,6 +22,104 @@ if [[ "$1" == mongo* ]]; then
 	if $numa true &> /dev/null; then
 		set -- $numa "$@"
 	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [ "$1" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		set -- "$@" --auth
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	definitelyAlreadyInitialized=
+	for path in \
+		/data/db/WiredTiger \
+		/data/db/journal \
+		/data/db/local.0 \
+		/data/db/storage.bson \
+	; do
+		if [ -e "$path" ]; then
+			definitelyAlreadyInitialized="$path"
+			break
+		fi
+	done
+
+	if [ -z "$definitelyAlreadyInitialized" ]; then
+		"$@" --fork --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1"
+
+		mongo=( mongo --quiet )
+
+		# check to see that "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, etc)
+		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+			echo >&2
+			echo >&2 'error: mongod does not appear to have started up -- perhaps it had an error?'
+			echo >&2
+			exit 1
+		fi
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(jq --arg 'user' "$MONGO_INITDB_ROOT_USERNAME" --null-input '$user'),
+					pwd: $(jq --arg 'pwd' "$MONGO_INITDB_ROOT_PASSWORD" --null-input '$pwd'),
+					roles: [ { role: 'root', db: $(jq --arg 'db' "$rootAuthDatabase" --null-input '$db') } ]
+				})
+			EOJS
+
+			mongo+=(
+				--username="$MONGO_INITDB_ROOT_USERNAME"
+				--password="$MONGO_INITDB_ROOT_PASSWORD"
+				--authenticationDatabase="$rootAuthDatabase"
+			)
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"$@" --shutdown
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	unset MONGO_INITDB_ROOT_USERNAME
+	unset MONGO_INITDB_ROOT_PASSWORD
+	unset MONGO_INITDB_DATABASE
 fi
 
 exec "$@"


### PR DESCRIPTION
Closes #52
Closes #53
Closes #89

This ensures that the initialization scripts will only run once, and _only_ offers the ability to create a user with the role of "root" -- authentication in MongoDB is fairly complex, so explicitly leaving more complex user setup to the user (via `/docker-entrypoint-initdb.d/*.js` or `*.sh`) seems prudent (essentially, only solving the most basic pain point of needing some way to invoke that initial `db.createUser` after enabling `--auth`).