### PR TITLE
Add a retry loop to initdb logic (handling the edge cases better)

### DIFF
--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -84,22 +84,35 @@ if [ "$1" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
-		"$@" --fork --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1"
+		pidfile="$(mktemp)"
+		trap "rm -f '$pidfile'" EXIT
+		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
 		mongo=( mongo --quiet )
 
-		# check to see that "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, etc)
-		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
-			# TODO figure out why only MongoDB 3.2 seems to exit from "--fork" before it's actually listening
-			# (adding "sleep 0.01" was sufficient on Tianon's local box, hence this tiny "retry up to one time")
-			sleep 5
-		fi
-		if ! "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
-			echo >&2
-			echo >&2 'error: mongod does not appear to have started up -- perhaps it had an error?'
-			echo >&2
-			exit 1
-		fi
+		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
+		tries=30
+		while true; do
+			if ! { [ -s "$pidfile" ] && ps "$(< "$pidfile")" &> /dev/null; }; then
+				# bail ASAP if "mongod" isn't even running
+				echo >&2
+				echo >&2 "error: $1 does not appear to have stayed running -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+				# success!
+				break
+			fi
+			(( tries-- ))
+			if [ "$tries" -le 0 ]; then
+				echo >&2
+				echo >&2 "error: $1 does not appear to have accepted connections quickly enough -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			sleep 1
+		done
 
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			rootAuthDatabase='admin'
@@ -131,7 +144,9 @@ if [ "$1" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --shutdown
+		"$@" --pidfilepath="$pidfile" --shutdown
+		rm "$pidfile"
+		trap - EXIT
 
 		echo
 		echo 'MongoDB init process complete; ready for start up.'


### PR DESCRIPTION
Fixes #150

Kudos to @yosifkit for the simpler idea of checking whether our `mongod` process even stays running before we try connecting as a really obvious "bail bail bail right away" indicator. :innocent: :heart: