### PR TITLE
Revert "Simplify docker-entrypoint for 3.4 (given the contract that "--fork" provides)"

### DIFF
--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -84,18 +84,36 @@ if [ "$1" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
-		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --fork
+		pidfile="$(mktemp)"
+		trap "rm -f '$pidfile'" EXIT
+		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
 		mongo=( mongo --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
-		# https://jira.mongodb.org/browse/SERVER-16292 (as of MongoDB 3.4+, the contract for "--fork" implies that once we get control back, the database is ready and listening for connections if it is going to be)
-		if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
-			echo >&2
-			echo >&2 "error: $1 does not appear to have started successfully -- perhaps it had an error?"
-			echo >&2
-			exit 1
-		fi
+		# https://jira.mongodb.org/browse/SERVER-16292
+		tries=30
+		while true; do
+			if ! { [ -s "$pidfile" ] && ps "$(< "$pidfile")" &> /dev/null; }; then
+				# bail ASAP if "mongod" isn't even running
+				echo >&2
+				echo >&2 "error: $1 does not appear to have stayed running -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+				# success!
+				break
+			fi
+			(( tries-- ))
+			if [ "$tries" -le 0 ]; then
+				echo >&2
+				echo >&2 "error: $1 does not appear to have accepted connections quickly enough -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			sleep 1
+		done
 
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			rootAuthDatabase='admin'
@@ -127,7 +145,9 @@ if [ "$1" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --shutdown
+		"$@" --pidfilepath="$pidfile" --shutdown
+		rm "$pidfile"
+		trap - EXIT
 
 		echo
 		echo 'MongoDB init process complete; ready for start up.'


### PR DESCRIPTION
Reverts docker-library/mongo#156

Turns out the contract (https://jira.mongodb.org/browse/SERVER-16292) is already broken in some edge cases. :disappointed: :sob: