### PR TITLE
Use a specific host/port on mongo/mongod for initdb scripts

### DIFF
--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -88,9 +88,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	if [ -z "$definitelyAlreadyInitialized" ]; then
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
-		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
+		"$@" --bind_ip 127.0.0.1 --port 27017 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
-		mongo=( mongo --quiet )
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -88,9 +88,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	if [ -z "$definitelyAlreadyInitialized" ]; then
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
-		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
+		"$@" --bind_ip 127.0.0.1 --port 27017 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
-		mongo=( mongo --quiet )
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -88,9 +88,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	if [ -z "$definitelyAlreadyInitialized" ]; then
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
-		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
+		"$@" --bind_ip 127.0.0.1 --port 27017 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
-		mongo=( mongo --quiet )
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/3.5/docker-entrypoint.sh
+++ b/3.5/docker-entrypoint.sh
@@ -88,9 +88,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	if [ -z "$definitelyAlreadyInitialized" ]; then
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
-		"$@" --bind_ip 127.0.0.1 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
+		"$@" --bind_ip 127.0.0.1 --port 27017 --logpath "/proc/$$/fd/1" --pidfilepath "$pidfile" --fork
 
-		mongo=( mongo --quiet )
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292


### PR DESCRIPTION
Fix for https://github.com/docker-library/mongo/commit/5fa47142887600edcd437e7689f40342b3572e71#commitcomment-21639425