### PR TITLE
Add a warning if "--config" is specified and we're going to attempt initdb

### DIFF
--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -123,6 +123,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
+		if _mongod_hack_have_arg --config "$@"; then
+			echo >&2
+			echo >&2 'warning: database is not yet initialized, and "--config" is specified'
+			echo >&2 '  the initdb database startup might fail as a result!'
+			echo >&2
+		fi
+
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
 		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "$@"

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -123,6 +123,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
+		if _mongod_hack_have_arg --config "$@"; then
+			echo >&2
+			echo >&2 'warning: database is not yet initialized, and "--config" is specified'
+			echo >&2 '  the initdb database startup might fail as a result!'
+			echo >&2
+		fi
+
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
 		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "$@"

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -123,6 +123,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
+		if _mongod_hack_have_arg --config "$@"; then
+			echo >&2
+			echo >&2 'warning: database is not yet initialized, and "--config" is specified'
+			echo >&2 '  the initdb database startup might fail as a result!'
+			echo >&2
+		fi
+
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
 		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "$@"

--- a/3.5/docker-entrypoint.sh
+++ b/3.5/docker-entrypoint.sh
@@ -123,6 +123,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	done
 
 	if [ -z "$definitelyAlreadyInitialized" ]; then
+		if _mongod_hack_have_arg --config "$@"; then
+			echo >&2
+			echo >&2 'warning: database is not yet initialized, and "--config" is specified'
+			echo >&2 '  the initdb database startup might fail as a result!'
+			echo >&2
+		fi
+
 		pidfile="$(mktemp)"
 		trap "rm -f '$pidfile'" EXIT
 		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "$@"


### PR DESCRIPTION
This will hopefully make the stuff we discussed over in https://github.com/docker-library/mongo/pull/167 more obvious to users when they run into it. :disappointed: