### PR TITLE
Leave ca-certificates installed

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+	&& apt-get purge -y --auto-remove wget
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -8,6 +8,7 @@ RUN echo 'deb http://deb.debian.org/debian wheezy-backports main' > /etc/apt/sou
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		ca-certificates \
 		jq \
 		numactl \
 # ps is not in base debian:wheezy image
@@ -17,7 +18,7 @@ RUN apt-get update \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -5,6 +5,7 @@ RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		ca-certificates	\
 		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
@@ -12,7 +13,7 @@ RUN apt-get update \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+	&& apt-get purge -y --auto-remove wget
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+	&& apt-get purge -y --auto-remove wget
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -5,6 +5,7 @@ RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		ca-certificates \
 		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
@@ -12,7 +13,7 @@ RUN apt-get update \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+	&& apt-get purge -y --auto-remove wget
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -5,6 +5,7 @@ RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		ca-certificates \
 		jq \
 		numactl \
 	&& rm -rf /var/lib/apt/lists/*
@@ -12,7 +13,7 @@ RUN apt-get update \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
A common use-case for the `mongo` image is to easily access the MongoDB CLI
where one is not natively installed. However, the `mongo` image currently
ships without `ca-certificates` which causes the CLI to fail when connecting
to MongoDB servers that require SSL.

The `ca-certificates` package is already installed during the build process
of this image, but it is removed during the build. This commit changes the
`Dockerfile` to leave `ca-certificates` installed. The size increase is
modest (~ 1 MB) but the increase in usefulness is vast.