### PR TITLE
mongo replica set option in entrypoint

### DIFF
--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -120,6 +120,14 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		exit 1
 	fi
 
+	if [ "$MONGO_REPLICA_SET" ] ; then
+		# if we have a replica set name, let's set "--replSet" and the replica set name.
+		_mongod_hack_ensure_arg '--replSet' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg "$MONGO_REPLICA_NAME" "$@"
+		set -- "${mongodHackedArgs[@]}"
+	fi
+
 	if [ -z "$shouldPerformInitdb" ]; then
 		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -120,6 +120,14 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		exit 1
 	fi
 
+	if [ "$MONGO_REPLICA_SET" ] ; then
+		# if we have a replica set name, let's set "--replSet" and the replica set name.
+		_mongod_hack_ensure_arg '--replSet' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg "$MONGO_REPLICA_NAME" "$@"
+		set -- "${mongodHackedArgs[@]}"
+	fi
+
 	if [ -z "$shouldPerformInitdb" ]; then
 		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -120,6 +120,14 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		exit 1
 	fi
 
+	if [ "$MONGO_REPLICA_SET" ] ; then
+		# if we have a replica set name, let's set "--replSet" and the replica set name.
+		_mongod_hack_ensure_arg '--replSet' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg "$MONGO_REPLICA_NAME" "$@"
+		set -- "${mongodHackedArgs[@]}"
+	fi
+
 	if [ -z "$shouldPerformInitdb" ]; then
 		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/3.5/docker-entrypoint.sh
+++ b/3.5/docker-entrypoint.sh
@@ -133,6 +133,14 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		exit 1
 	fi
 
+	if [ "$MONGO_REPLICA_SET" ] ; then
+		# if we have a replica set name, let's set "--replSet" and the replica set name.
+		_mongod_hack_ensure_arg '--replSet' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg "$MONGO_REPLICA_NAME" "$@"
+		set -- "${mongodHackedArgs[@]}"
+	fi
+
 	if [ -z "$shouldPerformInitdb" ]; then
 		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
 		for f in /docker-entrypoint-initdb.d/*; do


### PR DESCRIPTION
Following the #179 issue I have added an option in environment var to support the replica set with authentication, In order to achieve that you will need to set the username, password, and replica set name. This will not create a replica set but only enable the option to configure the container to a replica set.