### PR TITLE
Support for specifying version & type of MongoDB binary at docker builtime

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -43,11 +43,18 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
+# Allow build-time overrides (eg. to build image with MongoDB Enterprise version)
+# Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
+# Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
+# Example: docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .
+ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_REPO=repo.mongodb.org
+ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
+
 ENV MONGO_MAJOR 3.0
 ENV MONGO_VERSION 3.0.15
-ENV MONGO_PACKAGE mongodb-org
 
-RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+RUN echo "deb http://$MONGO_REPO/apt/debian wheezy/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -45,11 +45,18 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
+# Allow build-time overrides (eg. to build image with MongoDB Enterprise version)
+# Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
+# Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
+# Example: docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .
+ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_REPO=repo.mongodb.org
+ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
+
 ENV MONGO_MAJOR 3.2
 ENV MONGO_VERSION 3.2.14
-ENV MONGO_PACKAGE mongodb-org
 
-RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+RUN echo "deb http://$MONGO_REPO/apt/debian jessie/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -41,11 +41,18 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
+# Allow build-time overrides (eg. to build image with MongoDB Enterprise version)
+# Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
+# Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
+# Example: docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .
+ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_REPO=repo.mongodb.org
+ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
+
 ENV MONGO_MAJOR 3.4
 ENV MONGO_VERSION 3.4.5
-ENV MONGO_PACKAGE mongodb-org
 
-RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+RUN echo "deb http://$MONGO_REPO/apt/debian jessie/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -41,11 +41,18 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
+# Allow build-time overrides (eg. to build image with MongoDB Enterprise version)
+# Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
+# Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
+# Example: docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .
+ARG MONGO_PACKAGE=mongodb-org-unstable
+ARG MONGO_REPO=repo.mongodb.org
+ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
+
 ENV MONGO_MAJOR 3.5
 ENV MONGO_VERSION 3.5.8
-ENV MONGO_PACKAGE mongodb-org-unstable
 
-RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
+RUN echo "deb http://$MONGO_REPO/apt/debian jessie/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/update.sh
+++ b/update.sh
@@ -51,7 +51,7 @@ for version in "${versions[@]}"; do
 		sed -ri \
 			-e 's/^(ENV MONGO_MAJOR) .*/\1 '"$major"'/' \
 			-e 's/^(ENV MONGO_VERSION) .*/\1 '"$fullVersion"'/' \
-			-e 's/^(ENV MONGO_PACKAGE) .*/\1 '"$packageName"'/' \
+			-e 's/^(ARG MONGO_PACKAGE)=.*/\1='"$packageName"'/' \
 			"$version/Dockerfile"
 	)
 


### PR DESCRIPTION
I'd like to have the ability to provide docker buildtime overrides for versions of MongoDB generally, most critically allowing the user to choose to build an image based on MongoDB Enterprise version, rather than MongoDB Community version. See suggested and tested changes for 3.4 Dockerfile. I have not attempted to make changes to Dockerfiles of previous version (eg. 3.0, 3.2)

Once these changes are incorporated, this means users can pull down the "official" Mongo github project and build an image like:
$ docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .

..to produce a local Docker image that was built using MongoDB Enterprise, rather than the Community version (e.g. for paying MongoDB customers that want to leverage LDAP, Auditing and other advanced security features, but still leverage Docker and its "official" MongoDB project).