### PR TITLE
Add execute permission to docker-entrypoint.sh

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -71,6 +71,7 @@ RUN mkdir -p /data/db /data/configdb \
 VOLUME /data/db /data/configdb
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017


### PR DESCRIPTION
If the file (docker-entrypoint.sh) is not set to execute then you need to add the permission.