### PR TITLE
chmod for docker-entrypoint.sh on ver 3.6

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -85,6 +85,8 @@ RUN mkdir -p /data/db /data/configdb \
 VOLUME /data/db /data/configdb
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 777 /usr/local/bin/docker-entrypoint.sh \
+    && ln -s /usr/local/bin/docker-entrypoint.sh /
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017


### PR DESCRIPTION
to solve error below:
docker: Error response from daemon: OCI runtime create failed: container_linux.go:295: starting container process caused "exec: \"docker-entrypoint.sh\": executable file not found in $PATH": unknown.