### PR TITLE
Temporarily disable Windows builds

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -91,6 +91,10 @@ for version in "${versions[@]}"; do
 		windows/windowsservercore-{ltsc2016,1709} \
 		windows/nanoserver-{sac2016,1709} \
 	; do
+		# we run into https://github.com/moby/moby/issues/32838 fairly consistently
+		# as such, Windows builds are temporarily disabled
+		continue
+
 		dir="$version/$v"
 		variant="$(basename "$v")"
 


### PR DESCRIPTION
We run into https://github.com/moby/moby/issues/32838 with astonishing regularity, both on ltsc2016 and 1709 based image builds.

When this happens, the official images Windows builder gets stuck building "mongo", sometimes for days at a time, blocking the build of other images like "golang".

Once that issue is resolved (and the fix deployed to the official images build server), we can re-enable these builds.

Thanks to @jhowardmsft for helping me find https://github.com/moby/moby/issues/32838 and talking to me about the problem. :heart:

For posterity, here's an example of the error message:

```
re-exec error: exit status 1: output: time="2018-01-25T14:12:23-08:00" level=error msg="hcsshim::ImportLayer failed in Win32: The system cannot find the path specified. (0x3) layerId=\\\\?\\C:\\ProgramData\\Docker\\windowsfilter\\861be4c0adae5a864675d2ebf82563e599cbd42080b34f75072b4c35ae86bfdb flavour=1 folder=C:\\ProgramData\\Docker\\tmp\\hcs149100411"
hcsshim::ImportLayer failed in Win32: The system cannot find the path specified. (0x3) layerId=\\?\C:\ProgramData\Docker\windowsfilter\861be4c0adae5a864675d2ebf82563e599cbd42080b34f75072b4c35ae86bfdb flavour=1 folder=C:\ProgramData\Docker\tmp\hcs149100411
```