### PR TITLE
Add user account for MongoDB during init process

### DIFF
--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -180,6 +180,8 @@ _dbPath() {
 if [ "$originalArgOne" = 'mongod' ]; then
 	file_env 'MONGO_INITDB_ROOT_USERNAME'
 	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	file_env 'MONGO_INITDB_USERNAME'
+	file_env 'MONGO_INITDB_PASSWORD'
 	# pre-check a few factors to see if it's even worth bothering with initdb
 	shouldPerformInitdb=
 	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
@@ -301,6 +303,16 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 
 		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		if [ "$MONGO_INITDB_USERNAME" ] && [ "$MONGO_INITDB_PASSWORD" ]; then
+			"${mongo[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+				db.createUser({
+					user: $(_js_escape "$MONGO_INITDB_USERNAME"),
+					pwd: $(_js_escape "$MONGO_INITDB_PASSWORD"),
+					roles: [ { role: 'dbOwner', db: $(_js_escape "$MONGO_INITDB_DATABASE") } ]
+				})
+			EOJS
+		fi
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -180,6 +180,8 @@ _dbPath() {
 if [ "$originalArgOne" = 'mongod' ]; then
 	file_env 'MONGO_INITDB_ROOT_USERNAME'
 	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	file_env 'MONGO_INITDB_USERNAME'
+	file_env 'MONGO_INITDB_PASSWORD'
 	# pre-check a few factors to see if it's even worth bothering with initdb
 	shouldPerformInitdb=
 	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
@@ -301,6 +303,16 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 
 		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		if [ "$MONGO_INITDB_USERNAME" ] && [ "$MONGO_INITDB_PASSWORD" ]; then
+			"${mongo[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+				db.createUser({
+					user: $(_js_escape "$MONGO_INITDB_USERNAME"),
+					pwd: $(_js_escape "$MONGO_INITDB_PASSWORD"),
+					roles: [ { role: 'dbOwner', db: $(_js_escape "$MONGO_INITDB_DATABASE") } ]
+				})
+			EOJS
+		fi
 
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do


### PR DESCRIPTION
As well as root account creation this PR automates the creation of a non-root user with `dbOwner` role. https://docs.mongodb.com/manual/reference/built-in-roles/#dbOwner

To create a user for the default database (test or `MONGO_INITDB_DATABASE`) the two environment variables `MONGO_INITDB_USERNAME` and `MONGO_INITDB_PASSWORD` can be provided. This PR also supports injecting of the variables via Docker secrets.

Tried to keep this simple and hope it helps anyone when they need a new database with auth.