### PR TITLE
Re-enable Windows tags

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -108,10 +108,6 @@ for version in "${versions[@]}"; do
 		windows/windowsservercore-{ltsc2016,1709,1803} \
 		windows/nanoserver-{sac2016,1709,1803} \
 	; do
-		# we run into https://github.com/moby/moby/issues/32838 fairly consistently
-		# as such, Windows builds are temporarily disabled
-		continue
-
 		dir="$version/$v"
 		variant="$(basename "$v")"
 


### PR DESCRIPTION
See https://github.com/moby/moby/issues/32838#issuecomment-399622268. :tada:

Thanks @jhowardmsft :heart:

(I've successfully build-tested all these tags on our 1803 server.)