### PR TITLE
Duplicated `--pidfile`  during init if passed to mongod at startup

### DIFF
--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -311,7 +311,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --pidfilepath="$pidfile" --shutdown
+		"${mongodHackedArgs[@]}" --shutdown
 		rm -f "$pidfile"
 
 		echo

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -311,7 +311,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --pidfilepath="$pidfile" --shutdown
+		"${mongodHackedArgs[@]}" --shutdown
 		rm -f "$pidfile"
 
 		echo

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -312,7 +312,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --pidfilepath="$pidfile" --shutdown
+		"${mongodHackedArgs[@]}" --shutdown
 		rm -f "$pidfile"
 
 		echo

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -312,7 +312,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --pidfilepath="$pidfile" --shutdown
+		"${mongodHackedArgs[@]}" --shutdown
 		rm -f "$pidfile"
 
 		echo

--- a/4.1/docker-entrypoint.sh
+++ b/4.1/docker-entrypoint.sh
@@ -312,7 +312,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			echo
 		done
 
-		"$@" --pidfilepath="$pidfile" --shutdown
+		"${mongodHackedArgs[@]}" --shutdown
 		rm -f "$pidfile"
 
 		echo


### PR DESCRIPTION
I'm passing `--pidfilepath=/data/tmp/mongod.pid`. When init is finished and mongod is shutdown, this parameter becomes duplicated. So updated the shutdown command to `mongod --pidfilepath="$pidfile" --shutdown` (line 327) 



