### PR TITLE
Don't return null (as a string) when path doesn't exist in config, empty string instead

### DIFF
--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -168,7 +168,7 @@ _dbPath() {
 
 	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
 		if _parse_config "$@"; then
-			dbPath="$(jq -r '.storage.dbPath' "$jsonConfigFile")"
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
 		fi
 	fi
 

--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -168,7 +168,7 @@ _dbPath() {
 
 	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
 		if _parse_config "$@"; then
-			dbPath="$(jq -r '.storage.dbPath' "$jsonConfigFile")"
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
 		fi
 	fi
 

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -168,7 +168,7 @@ _dbPath() {
 
 	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
 		if _parse_config "$@"; then
-			dbPath="$(jq -r '.storage.dbPath' "$jsonConfigFile")"
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
 		fi
 	fi
 

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -168,7 +168,7 @@ _dbPath() {
 
 	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
 		if _parse_config "$@"; then
-			dbPath="$(jq -r '.storage.dbPath' "$jsonConfigFile")"
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
 		fi
 	fi
 

--- a/4.1/docker-entrypoint.sh
+++ b/4.1/docker-entrypoint.sh
@@ -168,7 +168,7 @@ _dbPath() {
 
 	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
 		if _parse_config "$@"; then
-			dbPath="$(jq -r '.storage.dbPath' "$jsonConfigFile")"
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
 		fi
 	fi
 


### PR DESCRIPTION
Fixes #303.

Equivalent to the empty string when used in a capturing subshell `"$( .. )"
```console
$ echo '{}' | jq -r '.foo'
null
$ echo '{}' | jq -r '.foo // empty'
$ echo '{}' | jq -r '.foo // ""'

$ a="$(echo '{}' | jq -r '.foo // empty')"
$ echo -n "$a"
$ b="$(echo '{}' | jq -r '.foo // ""')"
$ echo -n "$b"
$ 
```