### PR TITLE
Update _dbPath function to account for running as a config server

### DIFF
--- a/3.4/docker-entrypoint.sh
+++ b/3.4/docker-entrypoint.sh
@@ -172,6 +172,18 @@ _dbPath() {
 		fi
 	fi
 
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr']
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
 	: "${dbPath:=/data/db}"
 
 	echo "$dbPath"

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -172,6 +172,18 @@ _dbPath() {
 		fi
 	fi
 
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr']
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
 	: "${dbPath:=/data/db}"
 
 	echo "$dbPath"

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -172,6 +172,18 @@ _dbPath() {
 		fi
 	fi
 
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr']
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
 	: "${dbPath:=/data/db}"
 
 	echo "$dbPath"

--- a/4.1/docker-entrypoint.sh
+++ b/4.1/docker-entrypoint.sh
@@ -172,6 +172,18 @@ _dbPath() {
 		fi
 	fi
 
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr']
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
 	: "${dbPath:=/data/db}"
 
 	echo "$dbPath"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -172,6 +172,18 @@ _dbPath() {
 		fi
 	fi
 
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr']
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
 	: "${dbPath:=/data/db}"
 
 	echo "$dbPath"


### PR DESCRIPTION
Related to https://github.com/docker-library/mongo/issues/323#issuecomment-474243238 and https://github.com/docker-library/mongo/issues/329#issuecomment-476124342

>Declares that this `mongod` instance serves as the config server of a sharded cluster. When running with this option, clients (i.e. other cluster components) cannot write data to any database other than `config` and `admin`. The default port for a `mongod` with this option is `27019` and the default `--dbpath` directory is `/data/configdb`, unless specified.
>
> \- https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr