### PR TITLE
Move to Xenial + Bionic (4.1+ only) for more architectures

### DIFF
--- a/.architectures-lib
+++ b/.architectures-lib
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+hasBashbrewArch() {
+	local version="$1"; shift
+	local bashbrewArch="$1"; shift
+	local arches="$(grep -m1 'bashbrew-architectures:' "$version/Dockerfile" | cut -d':' -f2)"
+	[[ " $arches " == *" $bashbrewArch "* ]]
+}
+
+_generateParentRepoToArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -g -A parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|.*\/.*)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+_generateParentRepoToArches 'mongo'
+
+parentArches() {
+	local version="$1"; shift # "1.8", etc
+
+	local parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+	echo "${parentRepoToArches[$parent]:-}"
+}
+versionArches() {
+	local version="$1"; shift # "1.8", etc
+
+	local parentArches="$(parentArches "$version")"
+
+	local variantArches=()
+	for arch in $parentArches; do
+		if hasBashbrewArch "$version" "$arch"; then
+			variantArches+=( "$arch" )
+		fi
+	done
+	echo "${variantArches[*]}"
+}

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
@@ -16,9 +16,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.10.0
+ENV JSYAML_VERSION 3.13.0
 
 RUN set -ex; \
 	\
@@ -40,6 +40,7 @@ RUN set -ex; \
 	command -v gpgconf && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
 	gosu nobody true; \
 	\
 	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
@@ -70,8 +71,8 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR 3.4
 ENV MONGO_VERSION 3.4.20
-
-RUN echo "deb http://$MONGO_REPO/apt/debian jessie/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+# bashbrew-architectures:amd64 arm64v8
+RUN echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
@@ -16,9 +16,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.10.0
+ENV JSYAML_VERSION 3.13.0
 
 RUN set -ex; \
 	\
@@ -40,6 +40,7 @@ RUN set -ex; \
 	command -v gpgconf && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
 	gosu nobody true; \
 	\
 	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
@@ -70,8 +71,8 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR 3.6
 ENV MONGO_VERSION 3.6.11
-
-RUN echo "deb http://$MONGO_REPO/apt/debian stretch/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR main" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+# bashbrew-architectures:amd64 arm64v8
+RUN echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -16,9 +16,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.10.0
+ENV JSYAML_VERSION 3.13.0
 
 RUN set -ex; \
 	\
@@ -40,6 +40,7 @@ RUN set -ex; \
 	command -v gpgconf && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
 	gosu nobody true; \
 	\
 	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
@@ -70,7 +71,7 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR 4.0
 ENV MONGO_VERSION 4.0.8
-
+# bashbrew-architectures:amd64 arm64v8
 RUN echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
@@ -16,9 +16,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.10.0
+ENV JSYAML_VERSION 3.13.0
 
 RUN set -ex; \
 	\
@@ -40,6 +40,7 @@ RUN set -ex; \
 	command -v gpgconf && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
 	gosu nobody true; \
 	\
 	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
@@ -70,8 +71,8 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR 4.1
 ENV MONGO_VERSION 4.1.9
-
-RUN echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+# bashbrew-architectures:amd64 arm64v8 s390x
+RUN echo "deb http://$MONGO_REPO/apt/ubuntu bionic/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \
 	&& apt-get update \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -16,9 +16,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.11
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
-ENV JSYAML_VERSION 3.10.0
+ENV JSYAML_VERSION 3.13.0
 
 RUN set -ex; \
 	\
@@ -40,6 +40,7 @@ RUN set -ex; \
 	command -v gpgconf && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
 	gosu nobody true; \
 	\
 	wget -O /js-yaml.js "https://github.com/nodeca/js-yaml/raw/${JSYAML_VERSION}/dist/js-yaml.js"; \
@@ -70,7 +71,7 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR placeholder
 ENV MONGO_VERSION placeholder
-
+# bashbrew-architectures:%%ARCHES%%
 RUN echo "deb http://$MONGO_REPO/apt/%%DISTRO%% %%SUITE%%/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR %%COMPONENT%%" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 RUN set -x \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -11,6 +11,8 @@ declare -A aliases=(
 self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
+source '.architectures-lib'
+
 versions=( */ )
 versions=( "${versions[@]%/}" )
 
@@ -88,18 +90,12 @@ for version in "${versions[@]}"; do
 
 	major="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "MONGO_MAJOR" { print $3 }')"
 
-	variantArches=( amd64 )
-	if [ "$distro" = 'ubuntu' ]; then
-		variantArches+=( arm64v8 )
-	fi
-
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${variantAliases[@]}")
 		SharedTags: $(join ', ' "${versionAliases[@]}")
 		# see http://repo.mongodb.org/apt/$distro/dists/$suite/mongodb-org/$major/$component/
-		# (i386, ppc64el, s390x are empty)
-		Architectures: $(join ', ' "${variantArches[@]}")
+		Architectures: $(join ', ' $(versionArches "$version"))
 		GitCommit: $commit
 		Directory: $version
 	EOE


### PR DESCRIPTION
This also does explicit architecture detection from the upstream repos so that we stay accurate.

Looking at https://docs.mongodb.com/manual/installation/#arm64, this is in line and gets us `arm64v8` across the board! :+1: :tada: 