### PR TITLE
Circumventing permission issues when using nfs

### DIFF
--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -11,7 +11,7 @@ originalArgOne="$1"
 # all mongo* commands should be dropped to the correct user
 if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$originalArgOne" = 'mongod' ]; then
-		find /data/configdb /data/db \! -user mongodb -exec chown mongodb '{}' +
+		find /data/configdb /data/db -path /data/db/.snapshot -prune -o \! -user mongodb -exec chown mongodb '{}' +
 	fi
 
 	# make sure we can write to stdout and stderr as "mongodb"


### PR DESCRIPTION
How to reproduce: use image in k8s 1.11.6 with nfs-client-provisioner
and a netapp filer; this results in:
chown: changing ownership of '/data/db/.snapshot': Read-only file system

By ignoring .snapshot in the permission correction the container starts
flawlessly.

If this finds approval I can prepare PRs for other mongo versions.