### PR TITLE
docs: more precise version used in comment

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -160,7 +160,7 @@ for version in "${versions[@]}"; do
 		Dockerfile-linux.template \
 		> "$version/Dockerfile"
 
-	# starting with MongoDB 4.3 (and backported to 4.0 and 4.2??), the postinst for server includes an unconditional "systemctl daemon-reload" (and we don't have anything for "systemctl" to talk to leading to dbus errors and failed package installs)
+	# starting with MongoDB 4.3 (and backported to 4.2), the postinst for server includes an unconditional "systemctl daemon-reload" (and we don't have anything for "systemctl" to talk to leading to dbus errors and failed package installs)
 	case "$version" in
 		3.6)
 			sed -i -e '/systemctl/d' "$version/Dockerfile"


### PR DESCRIPTION
The comment hinted that the change for "systemctl" in the post-install file for debian was backported for version 4.0 and 4.2.

Looking at the [4.2 version](https://github.com/mongodb/mongo/blob/v4.2/debian/mongodb-org-server.postinst#L43) I see this backport.

But I don't see it for [version 4.0](https://github.com/mongodb/mongo/blob/v4.0/debian/mongodb-org-server.postinst#L43). (Looking at the [commit history](https://github.com/mongodb/mongo/commits/v4.0/debian/mongodb-org-server.postinst), it seems it was backported then reverted)