### PR TITLE
Force temporary server to use unix socket only

### DIFF
--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -141,8 +141,9 @@ _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
 }
 
-jsonConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-config.json"
-tempConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-temp-config.json"
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
 _parse_config() {
 	if [ -s "$tempConfigFile" ]; then
 		return 0
@@ -242,9 +243,11 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		if _parse_config "$@"; then
 			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
 		fi
-		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --bind_ip '' "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --unixSocketPrefix "$TMPDIR" "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --nounixsocket "${mongodHackedArgs[@]}"
 
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
@@ -278,13 +281,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
 
-		pidfile="${TMPDIR:-/tmp}/docker-entrypoint-temp-mongod.pid"
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
 		rm -f "$pidfile"
 		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
 
 		"${mongodHackedArgs[@]}" --fork
 
-		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+		mongo=( mongo --host "$TMPDIR/mongodb-27017.sock" --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -141,8 +141,9 @@ _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
 }
 
-jsonConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-config.json"
-tempConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-temp-config.json"
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
 _parse_config() {
 	if [ -s "$tempConfigFile" ]; then
 		return 0
@@ -242,9 +243,11 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		if _parse_config "$@"; then
 			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
 		fi
-		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --bind_ip '' "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --unixSocketPrefix "$TMPDIR" "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --nounixsocket "${mongodHackedArgs[@]}"
 
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
@@ -278,13 +281,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
 
-		pidfile="${TMPDIR:-/tmp}/docker-entrypoint-temp-mongod.pid"
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
 		rm -f "$pidfile"
 		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
 
 		"${mongodHackedArgs[@]}" --fork
 
-		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+		mongo=( mongo --host "$TMPDIR/mongodb-27017.sock" --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -141,8 +141,9 @@ _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
 }
 
-jsonConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-config.json"
-tempConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-temp-config.json"
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
 _parse_config() {
 	if [ -s "$tempConfigFile" ]; then
 		return 0
@@ -242,9 +243,11 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		if _parse_config "$@"; then
 			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
 		fi
-		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --bind_ip '' "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --unixSocketPrefix "$TMPDIR" "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --nounixsocket "${mongodHackedArgs[@]}"
 
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
@@ -278,13 +281,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
 
-		pidfile="${TMPDIR:-/tmp}/docker-entrypoint-temp-mongod.pid"
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
 		rm -f "$pidfile"
 		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
 
 		"${mongodHackedArgs[@]}" --fork
 
-		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+		mongo=( mongo --host "$TMPDIR/mongodb-27017.sock" --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -141,8 +141,9 @@ _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
 }
 
-jsonConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-config.json"
-tempConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-temp-config.json"
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
 _parse_config() {
 	if [ -s "$tempConfigFile" ]; then
 		return 0
@@ -242,9 +243,11 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		if _parse_config "$@"; then
 			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
 		fi
-		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --bind_ip '' "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --unixSocketPrefix "$TMPDIR" "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --nounixsocket "${mongodHackedArgs[@]}"
 
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
@@ -278,13 +281,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
 
-		pidfile="${TMPDIR:-/tmp}/docker-entrypoint-temp-mongod.pid"
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
 		rm -f "$pidfile"
 		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
 
 		"${mongodHackedArgs[@]}" --fork
 
-		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+		mongo=( mongo --host "$TMPDIR/mongodb-27017.sock" --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -141,8 +141,9 @@ _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
 }
 
-jsonConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-config.json"
-tempConfigFile="${TMPDIR:-/tmp}/docker-entrypoint-temp-config.json"
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
 _parse_config() {
 	if [ -s "$tempConfigFile" ]; then
 		return 0
@@ -242,9 +243,11 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		if _parse_config "$@"; then
 			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
 		fi
-		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --bind_ip '' "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --unixSocketPrefix "$TMPDIR" "${mongodHackedArgs[@]}"
 		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --nounixsocket "${mongodHackedArgs[@]}"
 
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
@@ -278,13 +281,13 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
 
-		pidfile="${TMPDIR:-/tmp}/docker-entrypoint-temp-mongod.pid"
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
 		rm -f "$pidfile"
 		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
 
 		"${mongodHackedArgs[@]}" --fork
 
-		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+		mongo=( mongo --host "$TMPDIR/mongodb-27017.sock" --quiet )
 
 		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
 		# https://jira.mongodb.org/browse/SERVER-16292


### PR DESCRIPTION
Consider this an official "request for comments" :sweat_smile:
(If your comment amounts to "I agree with this change" please just leave a thumbs up on this comment -- please don't make "+1" comments. :pray:)

This better matches the "initdb" behavior of the various SQL images, and avoids issues like running two instances in the same pod on different ports (and thus one of them failing to bind to 127.0.0.1:27017).

This is supported as of MongoDB 3.5+, and was discovered via https://stackoverflow.com/a/39901199/433558 -> https://jira.mongodb.org/browse/SERVER-9383 -> https://jira.mongodb.org/browse/SERVER-29403 (which was closed/fixed/implemented in 3.5.9).

Closes #440
Closes #437

This has implications for #437, #246, and probably many others, but for implementations like the one in https://github.com/docker-library/mongo/issues/246#issuecomment-627696906, this would actually make things better because the second container wouldn't even be able to connect until the first initialization is fully complete (as seen in "proper" external setup solutions like https://gist.github.com/crapthings/71fb6156a8e9b31a2fa7946ebd7c4edc).

For reference, here's the output of `rs.initiate()` on a daemon that's listening on the unix socket only:

```json
> rs.initiate();
{
	"operationTime" : Timestamp(0, 0),
	"ok" : 0,
	"errmsg" : "FailedToParse: Empty host component parsing HostAndPort from \":27017\" for member:{ _id: 0, host: \":27017\" }",
	"code" : 93,
	"codeName" : "InvalidReplicaSetConfig",
	"$clusterTime" : {
		"clusterTime" : Timestamp(0, 0),
		"signature" : {
			"hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
			"keyId" : NumberLong(0)
		}
	}
}
> rs.initiate({_id:"foo", members: [{"_id":1, "host":"test:27017"}]})
{
	"operationTime" : Timestamp(0, 0),
	"ok" : 0,
	"errmsg" : "No host described in new configuration with {version: 1, term: 0} for replica set foo maps to this node",
	"code" : 93,
	"codeName" : "InvalidReplicaSetConfig",
	"$clusterTime" : {
		"clusterTime" : Timestamp(0, 0),
		"signature" : {
			"hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
			"keyId" : NumberLong(0)
		}
	}
}
```

(Although IMO this isn't a huge deal because the [real "conclusion" from #246](https://github.com/docker-library/mongo/issues/246#issuecomment-469492453) is that it's not really reasonable to do `rs.initiate` from our initdb scripts anyhow and that users should be using external setup solutions like https://gist.github.com/crapthings/71fb6156a8e9b31a2fa7946ebd7c4edc instead.)