### PR TITLE
Fix the Windows ordering in generate-stackbrew-library.sh

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -100,8 +100,8 @@ for version in "${versions[@]}"; do
 	EOE
 
 	for v in \
-		windows/windowsservercore-{ltsc2016,1809} \
-		windows/nanoserver-{sac2016,1809} \
+		windows/windowsservercore-{1809,ltsc2016} \
+		windows/nanoserver-{1809,sac2016} \
 	; do
 		dir="$version/$v"
 		variant="$(basename "$v")"


### PR DESCRIPTION
This causes shared tags like `mongo:4.4` to always prefer the ltsc2016 version, since the entry order here ultimately controls the manifest list order, and the defined processing of manifest lists in the face of multiple supported images is to pick the first listed. :facepalm: