### PR TITLE
Support provisioning with replication enabled through configuration file.

### DIFF
--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -203,7 +203,7 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -203,7 +203,7 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -203,7 +203,7 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -203,7 +203,7 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -203,7 +203,7 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 


### PR DESCRIPTION
Allow for initialisation using `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD` and replication enabled.

Currently, when trying to run a mongo instance with `INITDB` env vars and replication enabled through a config file it throws the following error. It works fine when run with `--replSet`.

`{"t":{"$date":"2021-02-18T18:02:00.753+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn2","msg":"client metadata","attr":{"remote":"127.0.0.1:52968","client":"conn2","doc":{"application":{"name":"MongoDB Shell"},"driver":{"name":"MongoDB Internal Client","version":"4.4.4"},"os":{"type":"Linux","name":"Ubuntu","architecture":"x86_64","version":"18.04"}}}}
uncaught exception: Error: couldn't add user: not master :`