### PR TITLE
Create mongodb home dir in useradd command

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
+RUN set -ex; \
+	groupadd --system mongodb; \
+	useradd --system --gid mongodb --home-dir /var/mongodb --create-home mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
+RUN set -ex; \
+	groupadd --system mongodb; \
+	useradd --system --gid mongodb --home-dir /var/mongodb --create-home mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:bionic
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
+RUN set -ex; \
+	groupadd --system mongodb; \
+	useradd --system --gid mongodb --home-dir /var/mongodb --create-home mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:bionic
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
+RUN set -ex; \
+	groupadd --system mongodb; \
+	useradd --system --gid mongodb --home-dir /var/mongodb --create-home mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -1,7 +1,7 @@
 FROM placeholder
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
 
 RUN set -eux; \
 	apt-get update; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -1,7 +1,9 @@
 FROM placeholder
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r mongodb && useradd -m -r -g mongodb mongodb
+RUN set -ex; \
+	groupadd --system mongodb; \
+	useradd --system --gid mongodb --home-dir /var/mongodb --create-home mongodb
 
 RUN set -eux; \
 	apt-get update; \


### PR DESCRIPTION
Updates Dockerfile with `useradd -m` command.

Fixes [issue #323](https://github.com/docker-library/mongo/issues/323#issuecomment-494648458).

Users are annoyed when container commands try to save shell history and produce this message:
> Error saving history file: FileOpenFailed: Unable to open() file /home/mongodb/.dbshell: No such file or directory

Users create brittle workarounds when the Dockerfile should just create the home directory when creating the `mongodb` user. 
