### PR TITLE
Strip keyFile on initialization

### DIFF
--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -268,6 +268,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -268,6 +268,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -268,6 +268,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -268,6 +268,8 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -268,6 +268,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -268,6 +268,9 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
 		# https://github.com/docker-library/mongo/issues/211
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi


### PR DESCRIPTION
If the user passes `--keyFile`, `db.createUser` fails in user initialization script.