### PR TITLE
Added executable permissions for entrypoint script

### DIFF
--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -113,6 +113,7 @@ RUN mkdir -p /data/db /data/configdb \
 VOLUME /data/db /data/configdb
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 27017


### PR DESCRIPTION
Script execution getting failed when using pod security context in K8S, as the script is getting root permissions by default.