### PR TITLE
Add 5.0.4-rc0 and 5.1.0-rc3

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -84,8 +84,10 @@ ARG MONGO_PACKAGE=mongodb-org
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
-ENV MONGO_MAJOR 4.0
-RUN echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+RUN set -eux; \
+	{ \
+		echo "deb http://$MONGO_REPO/apt/ubuntu xenial/${MONGO_PACKAGE%-unstable}/4.0 multiverse"; \
+	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 # http://docs.mongodb.org/master/release-notes/4.0/
 ENV MONGO_VERSION 4.0.27

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -84,8 +84,10 @@ ARG MONGO_PACKAGE=mongodb-org
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
-ENV MONGO_MAJOR 4.2
-RUN echo "deb http://$MONGO_REPO/apt/ubuntu bionic/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+RUN set -eux; \
+	{ \
+		echo "deb http://$MONGO_REPO/apt/ubuntu bionic/${MONGO_PACKAGE%-unstable}/4.2 multiverse"; \
+	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 # http://docs.mongodb.org/master/release-notes/4.2/
 ENV MONGO_VERSION 4.2.17

--- a/5.0-rc/Dockerfile
+++ b/5.0-rc/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	set -- '20691EEC35216C63CAF66CE1656408E390CFB1F5'; \
+	set -- '20691EEC35216C63CAF66CE1656408E390CFB1F5' '9DA31620334BD75D9DCB49F368818C72E52529D4' 'E162F504A20CDF15827F718D4B7C549A058F8B6B' 'F5679A222C647C87527C2F8CB00A0BD1E2C63C11'; \
 	for key; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
@@ -86,12 +86,13 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 RUN set -eux; \
 	{ \
-		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/4.4 multiverse"; \
+		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/5.0 multiverse"; \
+		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/testing multiverse"; \
 	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
-# http://docs.mongodb.org/master/release-notes/4.4/
-ENV MONGO_VERSION 4.4.10
-# 10/13/2021, https://github.com/mongodb/mongo/tree/58971da1ef93435a9f62bf4708a81713def6e88c
+# http://docs.mongodb.org/master/release-notes/5.0/
+ENV MONGO_VERSION 5.0.4~rc0
+# 11/03/2021, https://github.com/mongodb/mongo/tree/62a84ede3cc9a334e8bc82160714df71e7d3a29e
 
 RUN set -x \
 # installing "mongodb-enterprise" pulls in "tzdata" which prompts for input

--- a/5.0-rc/docker-entrypoint.sh
+++ b/5.0-rc/docker-entrypoint.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+originalArgOne="$1"
+
+# allow the container to be started with `--user`
+# all mongo* commands should be dropped to the correct user
+if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$originalArgOne" = 'mongod' ]; then
+		find /data/configdb /data/db \! -user mongodb -exec chown mongodb '{}' +
+	fi
+
+	# make sure we can write to stdout and stderr as "mongodb"
+	# (for our "initdb" code later; see "--logpath" below)
+	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
+	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
+
+	exec gosu mongodb "$BASH_SOURCE" "$@"
+fi
+
+if dpkgArch="$(dpkg --print-architecture)" && [ "$dpkgArch" = 'amd64' ] && ! grep -qE '^flags.* avx( .*|$)' /proc/cpuinfo; then
+	# https://github.com/docker-library/mongo/issues/485#issuecomment-891991814
+	{
+		echo
+		echo 'WARNING: MongoDB 5.0+ requires a CPU with AVX support, and your current system does not appear to have that!'
+		echo '  see https://www.mongodb.com/community/forums/t/mongodb-5-0-cpu-intel-g4650-compatibility/116610/2'
+		echo '  see also https://github.com/docker-library/mongo/issues/485#issuecomment-891991814'
+		echo
+	} >&2
+fi
+
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$originalArgOne" == mongo* ]]; then
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# see https://github.com/docker-library/mongo/issues/147 (mongod is picky about duplicated arguments)
+_mongod_hack_have_arg() {
+	local checkArg="$1"; shift
+	local arg
+	for arg; do
+		case "$arg" in
+			"$checkArg"|"$checkArg"=*)
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+# _mongod_hack_get_arg_val '--some-arg' "$@"
+_mongod_hack_get_arg_val() {
+	local checkArg="$1"; shift
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$checkArg")
+				echo "$1"
+				return 0
+				;;
+			"$checkArg"=*)
+				echo "${arg#$checkArg=}"
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+declare -a mongodHackedArgs
+# _mongod_hack_ensure_arg '--some-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg() {
+	local ensureArg="$1"; shift
+	mongodHackedArgs=( "$@" )
+	if ! _mongod_hack_have_arg "$ensureArg" "$@"; then
+		mongodHackedArgs+=( "$ensureArg" )
+	fi
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		if [ "$arg" = "$ensureNoArg" ]; then
+			continue
+		fi
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg_val() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$ensureNoArg")
+				shift # also skip the value
+				continue
+				;;
+			"$ensureNoArg"=*)
+				# value is already included
+				continue
+				;;
+		esac
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_arg_val '--some-arg' 'some-val' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg_val() {
+	local ensureArg="$1"; shift
+	local ensureVal="$1"; shift
+	_mongod_hack_ensure_no_arg_val "$ensureArg" "$@"
+	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
+}
+
+# _js_escape 'some "string" value'
+_js_escape() {
+	jq --null-input --arg 'str' "$1" '$str'
+}
+
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
+_parse_config() {
+	if [ -s "$tempConfigFile" ]; then
+		return 0
+	fi
+
+	local configPath
+	if configPath="$(_mongod_hack_get_arg_val --config "$@")" && [ -s "$configPath" ]; then
+		# if --config is specified, parse it into a JSON file so we can remove a few problematic keys (especially SSL-related keys)
+		# see https://docs.mongodb.com/manual/reference/configuration-options/
+		if grep -vEm1 '^[[:space:]]*(#|$)' "$configPath" | grep -qE '^[[:space:]]*[^=:]+[[:space:]]*='; then
+			# if the first non-comment/non-blank line of the config file looks like "foo = ...", this is probably the 2.4 and older "ini-style config format"
+			# https://docs.mongodb.com/v2.4/reference/configuration-options/
+			# https://docs.mongodb.com/v2.6/reference/configuration-options/
+			# https://github.com/mongodb/mongo/blob/r4.4.2/src/mongo/util/options_parser/options_parser.cpp#L1359-L1375
+			# https://stackoverflow.com/a/25518018/433558
+			echo >&2
+			echo >&2 "WARNING: it appears that '$configPath' is in the older INI-style format (replaced by YAML in MongoDB 2.6)"
+			echo >&2 '  This script does not parse the older INI-style format, and thus will ignore it.'
+			echo >&2
+			return 1
+		fi
+		mongo --norc --nodb --quiet --eval "load('/js-yaml.js'); printjson(jsyaml.load(cat($(_js_escape "$configPath"))))" > "$jsonConfigFile"
+		if [ "$(head -c1 "$jsonConfigFile")" != '{' ] || [ "$(tail -c2 "$jsonConfigFile")" != '}' ]; then
+			# if the file doesn't start with "{" and end with "}", it's *probably* an error ("uncaught exception: YAMLException: foo" for example), so we should print it out
+			echo >&2 'error: unexpected "js-yaml.js" output while parsing config:'
+			cat >&2 "$jsonConfigFile"
+			exit 1
+		fi
+		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		return 0
+	fi
+
+	return 1
+}
+dbPath=
+_dbPath() {
+	if [ -n "$dbPath" ]; then
+		echo "$dbPath"
+		return
+	fi
+
+	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
+		if _parse_config "$@"; then
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
+		fi
+	fi
+
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr' ]
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
+	: "${dbPath:=/data/db}"
+
+	echo "$dbPath"
+}
+
+if [ "$originalArgOne" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	# pre-check a few factors to see if it's even worth bothering with initdb
+	shouldPerformInitdb=
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		# if we have a username/password, let's set "--auth"
+		_mongod_hack_ensure_arg '--auth' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		shouldPerformInitdb='true'
+	elif [ "$MONGO_INITDB_ROOT_USERNAME" ] || [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		cat >&2 <<-'EOF'
+
+			error: missing 'MONGO_INITDB_ROOT_USERNAME' or 'MONGO_INITDB_ROOT_PASSWORD'
+			       both must be specified for a user to be created
+
+		EOF
+		exit 1
+	fi
+
+	if [ -z "$shouldPerformInitdb" ]; then
+		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh|*.js) # this should match the set of files we check for below
+					shouldPerformInitdb="$f"
+					break
+					;;
+			esac
+		done
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	if [ -n "$shouldPerformInitdb" ]; then
+		dbPath="$(_dbPath "$@")"
+		for path in \
+			"$dbPath/WiredTiger" \
+			"$dbPath/journal" \
+			"$dbPath/local.0" \
+			"$dbPath/storage.bson" \
+		; do
+			if [ -e "$path" ]; then
+				shouldPerformInitdb=
+				break
+			fi
+		done
+	fi
+
+	if [ -n "$shouldPerformInitdb" ]; then
+		mongodHackedArgs=( "$@" )
+		if _parse_config "$@"; then
+			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+
+		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
+		# https://github.com/docker-library/mongo/issues/211
+		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+
+		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
+		tlsMode='disabled'
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "$@"; then
+			tlsMode='allowTLS'
+		elif _mongod_hack_have_arg '--sslPEMKeyFile' "$@"; then
+			tlsMode='allowSSL'
+		fi
+		# 4.2 switched all configuration/flag names from "SSL" to "TLS"
+		if [ "$tlsMode" = 'allowTLS' ] || mongod --help 2>&1 | grep -q -- ' --tlsMode '; then
+			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+		else
+			_mongod_hack_ensure_arg_val --sslMode "$tlsMode" "${mongodHackedArgs[@]}"
+		fi
+
+		if stat "/proc/$$/fd/1" > /dev/null && [ -w "/proc/$$/fd/1" ]; then
+			# https://github.com/mongodb/mongo/blob/38c0eb538d0fd390c6cb9ce9ae9894153f6e8ef5/src/mongo/db/initialize_server_global_state.cpp#L237-L251
+			# https://github.com/docker-library/mongo/issues/164#issuecomment-293965668
+			_mongod_hack_ensure_arg_val --logpath "/proc/$$/fd/1" "${mongodHackedArgs[@]}"
+		else
+			initdbLogPath="$(_dbPath "$@")/docker-initdb.log"
+			echo >&2 "warning: initdb logs cannot write to '/proc/$$/fd/1', so they are in '$initdbLogPath' instead"
+			_mongod_hack_ensure_arg_val --logpath "$initdbLogPath" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
+
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
+		rm -f "$pidfile"
+		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
+
+		"${mongodHackedArgs[@]}" --fork
+
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+
+		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
+		# https://jira.mongodb.org/browse/SERVER-16292
+		tries=30
+		while true; do
+			if ! { [ -s "$pidfile" ] && ps "$(< "$pidfile")" &> /dev/null; }; then
+				# bail ASAP if "mongod" isn't even running
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have stayed running -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+				# success!
+				break
+			fi
+			(( tries-- ))
+			if [ "$tries" -le 0 ]; then
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have accepted connections quickly enough -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			sleep 1
+		done
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+					pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+					roles: [ { role: 'root', db: $(_js_escape "$rootAuthDatabase") } ]
+				})
+			EOJS
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"${mongodHackedArgs[@]}" --shutdown
+		rm -f "$pidfile"
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	# MongoDB 3.6+ defaults to localhost-only binding
+	haveBindIp=
+	if _mongod_hack_have_arg --bind_ip "$@" || _mongod_hack_have_arg --bind_ip_all "$@"; then
+		haveBindIp=1
+	elif _parse_config "$@" && jq --exit-status '.net.bindIp // .net.bindIpAll' "$jsonConfigFile" > /dev/null; then
+		haveBindIp=1
+	fi
+	if [ -z "$haveBindIp" ]; then
+		# so if no "--bind_ip" is specified, let's add "--bind_ip_all"
+		set -- "$@" --bind_ip_all
+	fi
+
+	unset "${!MONGO_INITDB_@}"
+fi
+
+rm -f "$jsonConfigFile" "$tempConfigFile"
+
+exec "$@"

--- a/5.0-rc/windows/nanoserver-1809/Dockerfile
+++ b/5.0-rc/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,33 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+SHELL ["cmd", "/S", "/C"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "C:\mongodb\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+COPY --from=mongo:5.0.4-rc0-windowsservercore-1809 \
+	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\vcruntime140.dll \
+	C:\\Windows\\System32\\vcruntime140_1.dll \
+	C:\\Windows\\System32\\
+
+# http://docs.mongodb.org/master/release-notes/5.0/
+ENV MONGO_VERSION 5.0.4-rc0
+# 11/03/2021, https://github.com/mongodb/mongo/tree/62a84ede3cc9a334e8bc82160714df71e7d3a29e
+
+COPY --from=mongo:5.0.4-rc0-windowsservercore-1809 C:\\mongodb C:\\mongodb
+RUN mongo --version && mongod --version
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/5.0-rc/windows/windowsservercore-1809/Dockerfile
+++ b/5.0-rc/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,68 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# http://docs.mongodb.org/master/release-notes/5.0/
+ENV MONGO_VERSION 5.0.4-rc0
+# 11/03/2021, https://github.com/mongodb/mongo/tree/62a84ede3cc9a334e8bc82160714df71e7d3a29e
+
+ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.0.4-rc0-signed.msi
+ENV MONGO_DOWNLOAD_SHA256=267be2c606d41d42f1d050098241efebd45c6cc71cb16a071f7cf35b5611acc0
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	if ($env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+		if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+			Write-Host 'FAILED!'; \
+			exit 1; \
+		}; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'/l*v', 'install.log', \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows-unattended/#run-the-windows-installer-from-the-windows-command-interpreter
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=Client,MiscellaneousTools,Router,ServerNoService' \
+		); \
+	if (-Not (Test-Path C:\mongodb\bin\mongo.exe -PathType Leaf)) { \
+		Write-Host 'Installer failed!'; \
+		Get-Content install.log; \
+		exit 1; \
+	}; \
+	Remove-Item install.log; \
+	\
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/5.0-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/5.0-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,68 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# http://docs.mongodb.org/master/release-notes/5.0/
+ENV MONGO_VERSION 5.0.4-rc0
+# 11/03/2021, https://github.com/mongodb/mongo/tree/62a84ede3cc9a334e8bc82160714df71e7d3a29e
+
+ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.0.4-rc0-signed.msi
+ENV MONGO_DOWNLOAD_SHA256=267be2c606d41d42f1d050098241efebd45c6cc71cb16a071f7cf35b5611acc0
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	if ($env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+		if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+			Write-Host 'FAILED!'; \
+			exit 1; \
+		}; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'/l*v', 'install.log', \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows-unattended/#run-the-windows-installer-from-the-windows-command-interpreter
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=Client,MiscellaneousTools,Router,ServerNoService' \
+		); \
+	if (-Not (Test-Path C:\mongodb\bin\mongo.exe -PathType Leaf)) { \
+		Write-Host 'Installer failed!'; \
+		Get-Content install.log; \
+		exit 1; \
+	}; \
+	Remove-Item install.log; \
+	\
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -84,8 +84,10 @@ ARG MONGO_PACKAGE=mongodb-org
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
-ENV MONGO_MAJOR 5.0
-RUN echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+RUN set -eux; \
+	{ \
+		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/5.0 multiverse"; \
+	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 # http://docs.mongodb.org/master/release-notes/5.0/
 ENV MONGO_VERSION 5.0.3

--- a/5.1-rc/Dockerfile
+++ b/5.1-rc/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir /docker-entrypoint-initdb.d
 
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	set -- '20691EEC35216C63CAF66CE1656408E390CFB1F5'; \
+	set -- '20691EEC35216C63CAF66CE1656408E390CFB1F5' '9DA31620334BD75D9DCB49F368818C72E52529D4' 'E162F504A20CDF15827F718D4B7C549A058F8B6B' 'F5679A222C647C87527C2F8CB00A0BD1E2C63C11'; \
 	for key; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
@@ -80,18 +80,19 @@ RUN set -ex; \
 # Options for MONGO_PACKAGE: mongodb-org OR mongodb-enterprise
 # Options for MONGO_REPO: repo.mongodb.org OR repo.mongodb.com
 # Example: docker build --build-arg MONGO_PACKAGE=mongodb-enterprise --build-arg MONGO_REPO=repo.mongodb.com .
-ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_PACKAGE=mongodb-org-unstable
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 RUN set -eux; \
 	{ \
-		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/4.4 multiverse"; \
+		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/5.0 multiverse"; \
+		echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE%-unstable}/testing multiverse"; \
 	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
-# http://docs.mongodb.org/master/release-notes/4.4/
-ENV MONGO_VERSION 4.4.10
-# 10/13/2021, https://github.com/mongodb/mongo/tree/58971da1ef93435a9f62bf4708a81713def6e88c
+# http://docs.mongodb.org/master/release-notes/5.1/
+ENV MONGO_VERSION 5.1.0~rc3
+# 11/02/2021, https://github.com/mongodb/mongo/tree/29497d3d585581d97bd28e90d995f14470cc9b93
 
 RUN set -x \
 # installing "mongodb-enterprise" pulls in "tzdata" which prompts for input

--- a/5.1-rc/docker-entrypoint.sh
+++ b/5.1-rc/docker-entrypoint.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+originalArgOne="$1"
+
+# allow the container to be started with `--user`
+# all mongo* commands should be dropped to the correct user
+if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$originalArgOne" = 'mongod' ]; then
+		find /data/configdb /data/db \! -user mongodb -exec chown mongodb '{}' +
+	fi
+
+	# make sure we can write to stdout and stderr as "mongodb"
+	# (for our "initdb" code later; see "--logpath" below)
+	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
+	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
+
+	exec gosu mongodb "$BASH_SOURCE" "$@"
+fi
+
+if dpkgArch="$(dpkg --print-architecture)" && [ "$dpkgArch" = 'amd64' ] && ! grep -qE '^flags.* avx( .*|$)' /proc/cpuinfo; then
+	# https://github.com/docker-library/mongo/issues/485#issuecomment-891991814
+	{
+		echo
+		echo 'WARNING: MongoDB 5.0+ requires a CPU with AVX support, and your current system does not appear to have that!'
+		echo '  see https://www.mongodb.com/community/forums/t/mongodb-5-0-cpu-intel-g4650-compatibility/116610/2'
+		echo '  see also https://github.com/docker-library/mongo/issues/485#issuecomment-891991814'
+		echo
+	} >&2
+fi
+
+# you should use numactl to start your mongod instances, including the config servers, mongos instances, and any clients.
+# https://docs.mongodb.com/manual/administration/production-notes/#configuring-numa-on-linux
+if [[ "$originalArgOne" == mongo* ]]; then
+	numa='numactl --interleave=all'
+	if $numa true &> /dev/null; then
+		set -- $numa "$@"
+	fi
+fi
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# see https://github.com/docker-library/mongo/issues/147 (mongod is picky about duplicated arguments)
+_mongod_hack_have_arg() {
+	local checkArg="$1"; shift
+	local arg
+	for arg; do
+		case "$arg" in
+			"$checkArg"|"$checkArg"=*)
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+# _mongod_hack_get_arg_val '--some-arg' "$@"
+_mongod_hack_get_arg_val() {
+	local checkArg="$1"; shift
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$checkArg")
+				echo "$1"
+				return 0
+				;;
+			"$checkArg"=*)
+				echo "${arg#$checkArg=}"
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+declare -a mongodHackedArgs
+# _mongod_hack_ensure_arg '--some-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg() {
+	local ensureArg="$1"; shift
+	mongodHackedArgs=( "$@" )
+	if ! _mongod_hack_have_arg "$ensureArg" "$@"; then
+		mongodHackedArgs+=( "$ensureArg" )
+	fi
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		if [ "$arg" = "$ensureNoArg" ]; then
+			continue
+		fi
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_no_arg '--some-unwanted-arg' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_no_arg_val() {
+	local ensureNoArg="$1"; shift
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		case "$arg" in
+			"$ensureNoArg")
+				shift # also skip the value
+				continue
+				;;
+			"$ensureNoArg"=*)
+				# value is already included
+				continue
+				;;
+		esac
+		mongodHackedArgs+=( "$arg" )
+	done
+}
+# _mongod_hack_ensure_arg_val '--some-arg' 'some-val' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_ensure_arg_val() {
+	local ensureArg="$1"; shift
+	local ensureVal="$1"; shift
+	_mongod_hack_ensure_no_arg_val "$ensureArg" "$@"
+	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
+}
+
+# _js_escape 'some "string" value'
+_js_escape() {
+	jq --null-input --arg 'str' "$1" '$str'
+}
+
+: "${TMPDIR:=/tmp}"
+jsonConfigFile="$TMPDIR/docker-entrypoint-config.json"
+tempConfigFile="$TMPDIR/docker-entrypoint-temp-config.json"
+_parse_config() {
+	if [ -s "$tempConfigFile" ]; then
+		return 0
+	fi
+
+	local configPath
+	if configPath="$(_mongod_hack_get_arg_val --config "$@")" && [ -s "$configPath" ]; then
+		# if --config is specified, parse it into a JSON file so we can remove a few problematic keys (especially SSL-related keys)
+		# see https://docs.mongodb.com/manual/reference/configuration-options/
+		if grep -vEm1 '^[[:space:]]*(#|$)' "$configPath" | grep -qE '^[[:space:]]*[^=:]+[[:space:]]*='; then
+			# if the first non-comment/non-blank line of the config file looks like "foo = ...", this is probably the 2.4 and older "ini-style config format"
+			# https://docs.mongodb.com/v2.4/reference/configuration-options/
+			# https://docs.mongodb.com/v2.6/reference/configuration-options/
+			# https://github.com/mongodb/mongo/blob/r4.4.2/src/mongo/util/options_parser/options_parser.cpp#L1359-L1375
+			# https://stackoverflow.com/a/25518018/433558
+			echo >&2
+			echo >&2 "WARNING: it appears that '$configPath' is in the older INI-style format (replaced by YAML in MongoDB 2.6)"
+			echo >&2 '  This script does not parse the older INI-style format, and thus will ignore it.'
+			echo >&2
+			return 1
+		fi
+		mongo --norc --nodb --quiet --eval "load('/js-yaml.js'); printjson(jsyaml.load(cat($(_js_escape "$configPath"))))" > "$jsonConfigFile"
+		if [ "$(head -c1 "$jsonConfigFile")" != '{' ] || [ "$(tail -c2 "$jsonConfigFile")" != '}' ]; then
+			# if the file doesn't start with "{" and end with "}", it's *probably* an error ("uncaught exception: YAMLException: foo" for example), so we should print it out
+			echo >&2 'error: unexpected "js-yaml.js" output while parsing config:'
+			cat >&2 "$jsonConfigFile"
+			exit 1
+		fi
+		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" > "$tempConfigFile"
+		return 0
+	fi
+
+	return 1
+}
+dbPath=
+_dbPath() {
+	if [ -n "$dbPath" ]; then
+		echo "$dbPath"
+		return
+	fi
+
+	if ! dbPath="$(_mongod_hack_get_arg_val --dbpath "$@")"; then
+		if _parse_config "$@"; then
+			dbPath="$(jq -r '.storage.dbPath // empty' "$jsonConfigFile")"
+		fi
+	fi
+
+	if [ -z "$dbPath" ]; then
+		if _mongod_hack_have_arg --configsvr "$@" || {
+			_parse_config "$@" \
+			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+			&& [ "$clusterRole" = 'configsvr' ]
+		}; then
+			# if running as config server, then the default dbpath is /data/configdb
+			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
+			dbPath=/data/configdb
+		fi
+	fi
+
+	: "${dbPath:=/data/db}"
+
+	echo "$dbPath"
+}
+
+if [ "$originalArgOne" = 'mongod' ]; then
+	file_env 'MONGO_INITDB_ROOT_USERNAME'
+	file_env 'MONGO_INITDB_ROOT_PASSWORD'
+	# pre-check a few factors to see if it's even worth bothering with initdb
+	shouldPerformInitdb=
+	if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		# if we have a username/password, let's set "--auth"
+		_mongod_hack_ensure_arg '--auth' "$@"
+		set -- "${mongodHackedArgs[@]}"
+		shouldPerformInitdb='true'
+	elif [ "$MONGO_INITDB_ROOT_USERNAME" ] || [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+		cat >&2 <<-'EOF'
+
+			error: missing 'MONGO_INITDB_ROOT_USERNAME' or 'MONGO_INITDB_ROOT_PASSWORD'
+			       both must be specified for a user to be created
+
+		EOF
+		exit 1
+	fi
+
+	if [ -z "$shouldPerformInitdb" ]; then
+		# if we've got any /docker-entrypoint-initdb.d/* files to parse later, we should initdb
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh|*.js) # this should match the set of files we check for below
+					shouldPerformInitdb="$f"
+					break
+					;;
+			esac
+		done
+	fi
+
+	# check for a few known paths (to determine whether we've already initialized and should thus skip our initdb scripts)
+	if [ -n "$shouldPerformInitdb" ]; then
+		dbPath="$(_dbPath "$@")"
+		for path in \
+			"$dbPath/WiredTiger" \
+			"$dbPath/journal" \
+			"$dbPath/local.0" \
+			"$dbPath/storage.bson" \
+		; do
+			if [ -e "$path" ]; then
+				shouldPerformInitdb=
+				break
+			fi
+		done
+	fi
+
+	if [ -n "$shouldPerformInitdb" ]; then
+		mongodHackedArgs=( "$@" )
+		if _parse_config "$@"; then
+			_mongod_hack_ensure_arg_val --config "$tempConfigFile" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg_val --bind_ip 127.0.0.1 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_arg_val --port 27017 "${mongodHackedArgs[@]}"
+		_mongod_hack_ensure_no_arg --bind_ip_all "${mongodHackedArgs[@]}"
+
+		# remove "--auth" and "--replSet" for our initial startup (see https://docs.mongodb.com/manual/tutorial/enable-authentication/#start-mongodb-without-access-control)
+		# https://github.com/docker-library/mongo/issues/211
+		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
+		# "keyFile implies security.authorization"
+		# https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+
+		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
+		tlsMode='disabled'
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "$@"; then
+			tlsMode='allowTLS'
+		elif _mongod_hack_have_arg '--sslPEMKeyFile' "$@"; then
+			tlsMode='allowSSL'
+		fi
+		# 4.2 switched all configuration/flag names from "SSL" to "TLS"
+		if [ "$tlsMode" = 'allowTLS' ] || mongod --help 2>&1 | grep -q -- ' --tlsMode '; then
+			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+		else
+			_mongod_hack_ensure_arg_val --sslMode "$tlsMode" "${mongodHackedArgs[@]}"
+		fi
+
+		if stat "/proc/$$/fd/1" > /dev/null && [ -w "/proc/$$/fd/1" ]; then
+			# https://github.com/mongodb/mongo/blob/38c0eb538d0fd390c6cb9ce9ae9894153f6e8ef5/src/mongo/db/initialize_server_global_state.cpp#L237-L251
+			# https://github.com/docker-library/mongo/issues/164#issuecomment-293965668
+			_mongod_hack_ensure_arg_val --logpath "/proc/$$/fd/1" "${mongodHackedArgs[@]}"
+		else
+			initdbLogPath="$(_dbPath "$@")/docker-initdb.log"
+			echo >&2 "warning: initdb logs cannot write to '/proc/$$/fd/1', so they are in '$initdbLogPath' instead"
+			_mongod_hack_ensure_arg_val --logpath "$initdbLogPath" "${mongodHackedArgs[@]}"
+		fi
+		_mongod_hack_ensure_arg --logappend "${mongodHackedArgs[@]}"
+
+		pidfile="$TMPDIR/docker-entrypoint-temp-mongod.pid"
+		rm -f "$pidfile"
+		_mongod_hack_ensure_arg_val --pidfilepath "$pidfile" "${mongodHackedArgs[@]}"
+
+		"${mongodHackedArgs[@]}" --fork
+
+		mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+
+		# check to see that our "mongod" actually did start up (catches "--help", "--version", MongoDB 3.2 being silly, slow prealloc, etc)
+		# https://jira.mongodb.org/browse/SERVER-16292
+		tries=30
+		while true; do
+			if ! { [ -s "$pidfile" ] && ps "$(< "$pidfile")" &> /dev/null; }; then
+				# bail ASAP if "mongod" isn't even running
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have stayed running -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			if "${mongo[@]}" 'admin' --eval 'quit(0)' &> /dev/null; then
+				# success!
+				break
+			fi
+			(( tries-- ))
+			if [ "$tries" -le 0 ]; then
+				echo >&2
+				echo >&2 "error: $originalArgOne does not appear to have accepted connections quickly enough -- perhaps it had an error?"
+				echo >&2
+				exit 1
+			fi
+			sleep 1
+		done
+
+		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+			rootAuthDatabase='admin'
+
+			"${mongo[@]}" "$rootAuthDatabase" <<-EOJS
+				db.createUser({
+					user: $(_js_escape "$MONGO_INITDB_ROOT_USERNAME"),
+					pwd: $(_js_escape "$MONGO_INITDB_ROOT_PASSWORD"),
+					roles: [ { role: 'root', db: $(_js_escape "$rootAuthDatabase") } ]
+				})
+			EOJS
+		fi
+
+		export MONGO_INITDB_DATABASE="${MONGO_INITDB_DATABASE:-test}"
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh) echo "$0: running $f"; . "$f" ;;
+				*.js) echo "$0: running $f"; "${mongo[@]}" "$MONGO_INITDB_DATABASE" "$f"; echo ;;
+				*)    echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		"${mongodHackedArgs[@]}" --shutdown
+		rm -f "$pidfile"
+
+		echo
+		echo 'MongoDB init process complete; ready for start up.'
+		echo
+	fi
+
+	# MongoDB 3.6+ defaults to localhost-only binding
+	haveBindIp=
+	if _mongod_hack_have_arg --bind_ip "$@" || _mongod_hack_have_arg --bind_ip_all "$@"; then
+		haveBindIp=1
+	elif _parse_config "$@" && jq --exit-status '.net.bindIp // .net.bindIpAll' "$jsonConfigFile" > /dev/null; then
+		haveBindIp=1
+	fi
+	if [ -z "$haveBindIp" ]; then
+		# so if no "--bind_ip" is specified, let's add "--bind_ip_all"
+		set -- "$@" --bind_ip_all
+	fi
+
+	unset "${!MONGO_INITDB_@}"
+fi
+
+rm -f "$jsonConfigFile" "$tempConfigFile"
+
+exec "$@"

--- a/5.1-rc/windows/nanoserver-1809/Dockerfile
+++ b/5.1-rc/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,33 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+SHELL ["cmd", "/S", "/C"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "C:\mongodb\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+COPY --from=mongo:5.1.0-rc3-windowsservercore-1809 \
+	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\vcruntime140.dll \
+	C:\\Windows\\System32\\vcruntime140_1.dll \
+	C:\\Windows\\System32\\
+
+# http://docs.mongodb.org/master/release-notes/5.1/
+ENV MONGO_VERSION 5.1.0-rc3
+# 11/02/2021, https://github.com/mongodb/mongo/tree/29497d3d585581d97bd28e90d995f14470cc9b93
+
+COPY --from=mongo:5.1.0-rc3-windowsservercore-1809 C:\\mongodb C:\\mongodb
+RUN mongo --version && mongod --version
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/5.1-rc/windows/windowsservercore-1809/Dockerfile
+++ b/5.1-rc/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,68 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# http://docs.mongodb.org/master/release-notes/5.1/
+ENV MONGO_VERSION 5.1.0-rc3
+# 11/02/2021, https://github.com/mongodb/mongo/tree/29497d3d585581d97bd28e90d995f14470cc9b93
+
+ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.1.0-rc3-signed.msi
+ENV MONGO_DOWNLOAD_SHA256=24153e021234909444bd58a594f298325b348f159d34239345a5782adf6729a2
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	if ($env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+		if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+			Write-Host 'FAILED!'; \
+			exit 1; \
+		}; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'/l*v', 'install.log', \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows-unattended/#run-the-windows-installer-from-the-windows-command-interpreter
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=Client,MiscellaneousTools,Router,ServerNoService' \
+		); \
+	if (-Not (Test-Path C:\mongodb\bin\mongo.exe -PathType Leaf)) { \
+		Write-Host 'Installer failed!'; \
+		Get-Content install.log; \
+		exit 1; \
+	}; \
+	Remove-Item install.log; \
+	\
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/5.1-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/5.1-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,68 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# http://docs.mongodb.org/master/release-notes/5.1/
+ENV MONGO_VERSION 5.1.0-rc3
+# 11/02/2021, https://github.com/mongodb/mongo/tree/29497d3d585581d97bd28e90d995f14470cc9b93
+
+ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.1.0-rc3-signed.msi
+ENV MONGO_DOWNLOAD_SHA256=24153e021234909444bd58a594f298325b348f159d34239345a5782adf6729a2
+
+RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
+	\
+	if ($env:MONGO_DOWNLOAD_SHA256) { \
+		Write-Host ('Verifying sha256 ({0}) ...' -f $env:MONGO_DOWNLOAD_SHA256); \
+		if ((Get-FileHash mongo.msi -Algorithm sha256).Hash -ne $env:MONGO_DOWNLOAD_SHA256) { \
+			Write-Host 'FAILED!'; \
+			exit 1; \
+		}; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/#install-mongodb-community-edition
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			'mongo.msi', \
+			'/quiet', \
+			'/qn', \
+			'/l*v', 'install.log', \
+# https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows-unattended/#run-the-windows-installer-from-the-windows-command-interpreter
+			'INSTALLLOCATION=C:\mongodb', \
+			'ADDLOCAL=Client,MiscellaneousTools,Router,ServerNoService' \
+		); \
+	if (-Not (Test-Path C:\mongodb\bin\mongo.exe -PathType Leaf)) { \
+		Write-Host 'Installer failed!'; \
+		Get-Content install.log; \
+		exit 1; \
+	}; \
+	Remove-Item install.log; \
+	\
+	$env:PATH = 'C:\mongodb\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  mongo --version'; mongo --version; \
+	Write-Host '  mongod --version'; mongod --version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item C:\windows\installer\*.msi -Force; \
+	Remove-Item mongo.msi -Force; \
+	\
+	Write-Host 'Complete.';
+
+# TODO docker-entrypoint.ps1 ? (for "docker run <image> --flag --flag --flag")
+
+VOLUME C:\\data\\db C:\\data\\configdb
+
+EXPOSE 27017
+CMD ["mongod", "--bind_ip_all"]

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -79,8 +79,28 @@ ARG MONGO_PACKAGE=mongodb-org{{ if (env.version != env.rcVersion) and (env.rcVer
 ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
-ENV MONGO_MAJOR {{ if env.version != env.rcVersion then "testing" else env.version end }}
-RUN echo "deb http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR {{ if target.image | test("^debian") then "main" else "multiverse" end }}" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
+RUN set -eux; \
+	{ \
+{{
+	[
+		[
+			# without adding *both*, RCs will often fail to find the "mongodb-mongosh" package (because it's not in the "testing" repository)
+			if env.version == "5.1-rc" then
+				"5.0" # just to get the elusive "mongodb-mongosh" package because "5.1" doesn't exist yet and "testing" does not include it 😩
+			else
+				env.rcVersion
+			end,
+			if env.version != env.rcVersion then
+				"testing"
+			else empty end
+		][] as $major | (
+-}}
+		echo "deb http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/{{ $major }} {{ if target.image | test("^debian") then "main" else "multiverse" end }}"; \
+{{
+		)
+	] | add
+-}}
+	} | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 
 {{ if .notes then ( -}}
 # {{ .notes }}

--- a/versions.json
+++ b/versions.json
@@ -220,5 +220,118 @@
     },
     "version": "5.0.3"
   },
-  "5.0-rc": null
+  "5.0-rc": {
+    "changes": "https://jira.mongodb.org/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%225.0.4%22%20ORDER%20BY%20status%20DESC%2C%20priority%20DESC",
+    "date": "11/03/2021",
+    "githash": "62a84ede3cc9a334e8bc82160714df71e7d3a29e",
+    "gpg": [
+      "20691EEC35216C63CAF66CE1656408E390CFB1F5",
+      "9DA31620334BD75D9DCB49F368818C72E52529D4",
+      "E162F504A20CDF15827F718D4B7C549A058F8B6B",
+      "F5679A222C647C87527C2F8CB00A0BD1E2C63C11"
+    ],
+    "linux": "ubuntu2004",
+    "notes": "http://docs.mongodb.org/master/release-notes/5.0/",
+    "targets": {
+      "debian10": {
+        "arches": [
+          "amd64"
+        ],
+        "image": "debian:buster-slim",
+        "suite": "buster"
+      },
+      "ubuntu1804": {
+        "arches": [
+          "amd64",
+          "arm64v8"
+        ],
+        "image": "ubuntu:bionic",
+        "suite": "bionic"
+      },
+      "ubuntu2004": {
+        "arches": [
+          "amd64",
+          "arm64v8"
+        ],
+        "image": "ubuntu:focal",
+        "suite": "focal"
+      },
+      "windows": {
+        "arches": [
+          "amd64"
+        ],
+        "features": [
+          "Client",
+          "MiscellaneousTools",
+          "Router",
+          "ServerNoService"
+        ],
+        "msi": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.0.4-rc0-signed.msi",
+        "sha256": "267be2c606d41d42f1d050098241efebd45c6cc71cb16a071f7cf35b5611acc0",
+        "variants": [
+          "windowsservercore-1809",
+          "windowsservercore-ltsc2016",
+          "nanoserver-1809"
+        ]
+      }
+    },
+    "version": "5.0.4-rc0"
+  },
+  "5.1-rc": {
+    "changes": "https://jira.mongodb.org/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%225.1.0%22%20ORDER%20BY%20status%20DESC%2C%20priority%20DESC",
+    "date": "11/02/2021",
+    "githash": "29497d3d585581d97bd28e90d995f14470cc9b93",
+    "gpg": [
+      "20691EEC35216C63CAF66CE1656408E390CFB1F5",
+      "9DA31620334BD75D9DCB49F368818C72E52529D4",
+      "E162F504A20CDF15827F718D4B7C549A058F8B6B",
+      "F5679A222C647C87527C2F8CB00A0BD1E2C63C11"
+    ],
+    "linux": "ubuntu2004",
+    "notes": "http://docs.mongodb.org/master/release-notes/5.1/",
+    "targets": {
+      "debian10": {
+        "arches": [
+          "amd64"
+        ],
+        "image": "debian:buster-slim",
+        "suite": "buster"
+      },
+      "ubuntu1804": {
+        "arches": [
+          "amd64",
+          "arm64v8"
+        ],
+        "image": "ubuntu:bionic",
+        "suite": "bionic"
+      },
+      "ubuntu2004": {
+        "arches": [
+          "amd64",
+          "arm64v8"
+        ],
+        "image": "ubuntu:focal",
+        "suite": "focal"
+      },
+      "windows": {
+        "arches": [
+          "amd64"
+        ],
+        "features": [
+          "Client",
+          "MiscellaneousTools",
+          "Router",
+          "ServerNoService"
+        ],
+        "msi": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.1.0-rc3-signed.msi",
+        "sha256": "24153e021234909444bd58a594f298325b348f159d34239345a5782adf6729a2",
+        "variants": [
+          "windowsservercore-1809",
+          "windowsservercore-ltsc2016",
+          "nanoserver-1809"
+        ]
+      }
+    },
+    "version": "5.1.0-rc3"
+  }
 }


### PR DESCRIPTION
We keep running into the following for 5.0+ RCs, so I think it's time to address it:

```console
+ apt-get install -y mongodb-org=5.0.4~rc0 mongodb-org-server=5.0.4~rc0 mongodb-org-shell=5.0.4~rc0 mongodb-org-mongos=5.0.4~rc0 mongodb-org-tools=5.0.4~rc0
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 mongodb-org : Depends: mongodb-mongosh but it is not installable
E: Unable to correct problems, you have held broken packages.
Removing intermediate container 87166299d7cf
The command '/bin/sh -c set -x 	&& export DEBIAN_FRONTEND=noninteractive 	&& apt-get update 	&& ln -s /bin/true /usr/local/bin/systemctl 	&& apt-get install -y 		${MONGO_PACKAGE}=$MONGO_VERSION 		${MONGO_PACKAGE}-server=$MONGO_VERSION 		${MONGO_PACKAGE}-shell=$MONGO_VERSION 		${MONGO_PACKAGE}-mongos=$MONGO_VERSION 		${MONGO_PACKAGE}-tools=$MONGO_VERSION 	&& rm -f /usr/local/bin/systemctl 	&& rm -rf /var/lib/apt/lists/* 	&& rm -rf /var/lib/mongodb 	&& mv /etc/mongod.conf /etc/mongod.conf.orig' returned a non-zero code: 100
```