### PR TITLE
Explicitly skip all "rapid releases"

### DIFF
--- a/gpg-keys.txt
+++ b/gpg-keys.txt
@@ -1,9 +1,9 @@
 # this file's values are updated via "./gpg-keys.sh"
 
 5.0:F5679A222C647C87527C2F8CB00A0BD1E2C63C11
-# TODO https://github.com/docker-library/mongo/pull/483#issuecomment-879225967
 4.4:20691EEC35216C63CAF66CE1656408E390CFB1F5
 4.2:E162F504A20CDF15827F718D4B7C549A058F8B6B
 4.0:9DA31620334BD75D9DCB49F368818C72E52529D4
 
 # these all come directly via https://www.mongodb.org/static/pgp/server-X.Y.asc
+# see https://www.mongodb.org/static/pgp/?C=M;O=D

--- a/versions.sh
+++ b/versions.sh
@@ -52,6 +52,14 @@ shell="$(
 				"3.6", # April 2021
 				null # ... so we can have a trailing comma above, making diffs nicer :trollface:
 			] | index($v) | not)
+
+			# filter out so-called "rapid releases": https://docs.mongodb.com/upcoming/reference/versioning/
+			# "Rapid Releases are designed for use with MongoDB Atlas, and are not generally supported for use in an on-premise capacity."
+			| select(
+				(.version | split(".")) as $splitVersion
+				| ($splitVersion[0] | tonumber) >= 5 and ($splitVersion[1] | tonumber) > 0
+				| not
+			)
 		]
 
 		# now convert all that data to a basic shell list + map so we can loop over/use it appropriately


### PR DESCRIPTION
See https://docs.mongodb.com/upcoming/reference/versioning/, especially:

> Rapid Releases are designed for use with MongoDB Atlas, and are not generally supported for use in an on-premise capacity.

Refs #515