### PR TITLE
Fix configsvr with user/pass env vars on 5.0 & 6.0

### DIFF
--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -206,12 +206,21 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication, .sharding)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 
 	return 1
 }
+
+_isConfigServer() {
+	_mongod_hack_have_arg --configsvr "$@" || {
+		_parse_config "$@" \
+		&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+		&& [ "$clusterRole" = 'configsvr' ]
+	}
+}
+
 dbPath=
 _dbPath() {
 	if [ -n "$dbPath" ]; then
@@ -226,11 +235,7 @@ _dbPath() {
 	fi
 
 	if [ -z "$dbPath" ]; then
-		if _mongod_hack_have_arg --configsvr "$@" || {
-			_parse_config "$@" \
-			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
-			&& [ "$clusterRole" = 'configsvr' ]
-		}; then
+		if _isConfigServer "$@"; then
 			# if running as config server, then the default dbpath is /data/configdb
 			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
 			dbPath=/data/configdb
@@ -313,6 +318,12 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+		# Setting sharding.clusterRole=configsvr requires the mongod instance to be running with replication
+		# disable configsvr for initial startup (https://github.com/docker-library/mongo/issues/509)
+		if _isConfigServer "$@"; then
+			_mongod_hack_ensure_no_arg '--configsvr' "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val '--dbpath' "$dbPath" "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"

--- a/4.4/docker-entrypoint.sh
+++ b/4.4/docker-entrypoint.sh
@@ -206,12 +206,21 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication, .sharding)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 
 	return 1
 }
+
+_isConfigServer() {
+	_mongod_hack_have_arg --configsvr "$@" || {
+		_parse_config "$@" \
+		&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+		&& [ "$clusterRole" = 'configsvr' ]
+	}
+}
+
 dbPath=
 _dbPath() {
 	if [ -n "$dbPath" ]; then
@@ -226,11 +235,7 @@ _dbPath() {
 	fi
 
 	if [ -z "$dbPath" ]; then
-		if _mongod_hack_have_arg --configsvr "$@" || {
-			_parse_config "$@" \
-			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
-			&& [ "$clusterRole" = 'configsvr' ]
-		}; then
+		if _isConfigServer "$@"; then
 			# if running as config server, then the default dbpath is /data/configdb
 			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
 			dbPath=/data/configdb
@@ -313,6 +318,12 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+		# Setting sharding.clusterRole=configsvr requires the mongod instance to be running with replication
+		# disable configsvr for initial startup (https://github.com/docker-library/mongo/issues/509)
+		if _isConfigServer "$@"; then
+			_mongod_hack_ensure_no_arg '--configsvr' "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val '--dbpath' "$dbPath" "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -206,12 +206,21 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication, .sharding)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 
 	return 1
 }
+
+_isConfigServer() {
+	_mongod_hack_have_arg --configsvr "$@" || {
+		_parse_config "$@" \
+		&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+		&& [ "$clusterRole" = 'configsvr' ]
+	}
+}
+
 dbPath=
 _dbPath() {
 	if [ -n "$dbPath" ]; then
@@ -226,11 +235,7 @@ _dbPath() {
 	fi
 
 	if [ -z "$dbPath" ]; then
-		if _mongod_hack_have_arg --configsvr "$@" || {
-			_parse_config "$@" \
-			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
-			&& [ "$clusterRole" = 'configsvr' ]
-		}; then
+		if _isConfigServer "$@"; then
 			# if running as config server, then the default dbpath is /data/configdb
 			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
 			dbPath=/data/configdb
@@ -313,6 +318,12 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+		# Setting sharding.clusterRole=configsvr requires the mongod instance to be running with replication
+		# disable configsvr for initial startup (https://github.com/docker-library/mongo/issues/509)
+		if _isConfigServer "$@"; then
+			_mongod_hack_ensure_no_arg '--configsvr' "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val '--dbpath' "$dbPath" "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -206,12 +206,21 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication, .sharding)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 
 	return 1
 }
+
+_isConfigServer() {
+	_mongod_hack_have_arg --configsvr "$@" || {
+		_parse_config "$@" \
+		&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+		&& [ "$clusterRole" = 'configsvr' ]
+	}
+}
+
 dbPath=
 _dbPath() {
 	if [ -n "$dbPath" ]; then
@@ -226,11 +235,7 @@ _dbPath() {
 	fi
 
 	if [ -z "$dbPath" ]; then
-		if _mongod_hack_have_arg --configsvr "$@" || {
-			_parse_config "$@" \
-			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
-			&& [ "$clusterRole" = 'configsvr' ]
-		}; then
+		if _isConfigServer "$@"; then
 			# if running as config server, then the default dbpath is /data/configdb
 			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
 			dbPath=/data/configdb
@@ -313,6 +318,12 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+		# Setting sharding.clusterRole=configsvr requires the mongod instance to be running with replication
+		# disable configsvr for initial startup (https://github.com/docker-library/mongo/issues/509)
+		if _isConfigServer "$@"; then
+			_mongod_hack_ensure_no_arg '--configsvr' "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val '--dbpath' "$dbPath" "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -206,12 +206,21 @@ _parse_config() {
 			cat >&2 "$jsonConfigFile"
 			exit 1
 		fi
-		jq 'del(.systemLog, .processManagement, .net, .security, .replication)' "$jsonConfigFile" > "$tempConfigFile"
+		jq 'del(.systemLog, .processManagement, .net, .security, .replication, .sharding)' "$jsonConfigFile" > "$tempConfigFile"
 		return 0
 	fi
 
 	return 1
 }
+
+_isConfigServer() {
+	_mongod_hack_have_arg --configsvr "$@" || {
+		_parse_config "$@" \
+		&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
+		&& [ "$clusterRole" = 'configsvr' ]
+	}
+}
+
 dbPath=
 _dbPath() {
 	if [ -n "$dbPath" ]; then
@@ -226,11 +235,7 @@ _dbPath() {
 	fi
 
 	if [ -z "$dbPath" ]; then
-		if _mongod_hack_have_arg --configsvr "$@" || {
-			_parse_config "$@" \
-			&& clusterRole="$(jq -r '.sharding.clusterRole // empty' "$jsonConfigFile")" \
-			&& [ "$clusterRole" = 'configsvr' ]
-		}; then
+		if _isConfigServer "$@"; then
 			# if running as config server, then the default dbpath is /data/configdb
 			# https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-configsvr
 			dbPath=/data/configdb
@@ -313,6 +318,12 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg_val --keyFile "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+		fi
+		# Setting sharding.clusterRole=configsvr requires the mongod instance to be running with replication
+		# disable configsvr for initial startup (https://github.com/docker-library/mongo/issues/509)
+		if _isConfigServer "$@"; then
+			_mongod_hack_ensure_no_arg '--configsvr' "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val '--dbpath' "$dbPath" "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"


### PR DESCRIPTION
Since 5.0, setting the `sharding.clusterRole`/`--configsvr` [requires it to be part of a replica set](https://www.mongodb.com/docs/v5.0/reference/configuration-options/#mongodb-setting-sharding.clusterRole) so this fixes part of #509 (for `--configsvr`). Not certain we need to do anything for `--shardsvr` since they shouldn't use the entrypoint user/pass or `initdb.d` scripts there.
```console
BadValue: Cannot start a configsvr as a standalone server. Please use the option --replSet to start the node as a replica set.
try 'mongod --help' for more information
```

Technically, adding `--auth` (via adding user/pass) also requires a `keyFile` for a `replset`, but that is something the user needs to add (not something we can fix in the entrypoint)
```console
$ docker run -it --rm \
-v "$PWD/data:/data/configdb" \
-v "$PWD/keyfile:/keyfile:ro" \
--user [data & keyfile directory owner] \
--env MONGO_INITDB_ROOT_USERNAME=admin \
--env MONGO_INITDB_ROOT_PASSWORD=password \
--name mongo-cfg \
mongo:6.0 --configsvr --replSet rep --keyFile /keyfile/test.key
```
(I'd recommend users also set `--hostname` when using replica sets depending on how they set up members in their replica configuration `rs.init(...)`.)