### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		dirmngr \
 		gnupg \
 		jq \
 		numactl \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		dirmngr \
 		gnupg \
 		jq \
 		numactl \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		dirmngr \
 		gnupg \
 		jq \
 		numactl \

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		dirmngr \
 		gnupg \
 		jq \
 		numactl \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -12,7 +12,6 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		dirmngr \
 		gnupg \
 		jq \
 		numactl \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).