### PR TITLE
Add missing dll for 8.0.0-rc8 nanoserver

### DIFF
--- a/5.0/windows/nanoserver-1809/Dockerfile
+++ b/5.0/windows/nanoserver-1809/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:5.0.27-windowsservercore-1809 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/5.0/windows/nanoserver-ltsc2022/Dockerfile
+++ b/5.0/windows/nanoserver-ltsc2022/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:5.0.27-windowsservercore-ltsc2022 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/6.0-rc/windows/nanoserver-1809/Dockerfile
+++ b/6.0-rc/windows/nanoserver-1809/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:6.0.16-rc0-windowsservercore-1809 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/6.0-rc/windows/nanoserver-ltsc2022/Dockerfile
+++ b/6.0-rc/windows/nanoserver-ltsc2022/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:6.0.16-rc0-windowsservercore-ltsc2022 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/6.0/windows/nanoserver-1809/Dockerfile
+++ b/6.0/windows/nanoserver-1809/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:6.0.15-windowsservercore-1809 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/6.0/windows/nanoserver-ltsc2022/Dockerfile
+++ b/6.0/windows/nanoserver-ltsc2022/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:6.0.15-windowsservercore-ltsc2022 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/7.0/windows/nanoserver-1809/Dockerfile
+++ b/7.0/windows/nanoserver-1809/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:7.0.11-windowsservercore-1809 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/7.0/windows/nanoserver-ltsc2022/Dockerfile
+++ b/7.0/windows/nanoserver-ltsc2022/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:7.0.11-windowsservercore-ltsc2022 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/8.0-rc/windows/nanoserver-1809/Dockerfile
+++ b/8.0-rc/windows/nanoserver-1809/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:8.0.0-rc8-windowsservercore-1809 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/8.0-rc/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8.0-rc/windows/nanoserver-ltsc2022/Dockerfile
@@ -16,6 +16,7 @@ USER ContainerUser
 
 COPY --from=mongo:8.0.0-rc8-windowsservercore-ltsc2022 \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -78,6 +78,7 @@ USER ContainerUser
 {{ def copy_from: "mongo:" + .version + "-windowsservercore-" + env.windowsRelease -}}
 COPY --from={{ copy_from }} \
 	C:\\Windows\\System32\\msvcp140.dll \
+	C:\\Windows\\System32\\msvcp140_1.dll \
 	C:\\Windows\\System32\\vcruntime140.dll \
 	C:\\Windows\\System32\\vcruntime140_1.dll \
 	C:\\Windows\\System32\\


### PR DESCRIPTION
The 8.0.0-rc8 nanoserver images are failing to build:

```console
Step 8/12 : COPY --from=mongo:8.0.0-rc8-windowsservercore-ltsc2022 C:\\mongodb C:\\mongodb
 ---> eb170d31ebdd
Step 9/12 : RUN mongod --version
 ---> Running in e6f3a0d9381c
The command 'cmd /S /C mongod --version' returned a non-zero code: 3221225781
```
🔍 After searching through the DLLs loaded by `mongod.exe` at runtime, it turns out that `msvcp140_1.dll` is needed on `nanoserver`. We might be missing other DLLs for MongoDB features that aren't loaded when doing `mongod --version`.

For reference, this is the `C:/Windows/System32/` folder from the MongoDB installation layer in the `windowsservercore` [image](https://oci.dag.dev/fs/mongo:8.0.0-rc7-windowsservercore-ltsc2022@sha256:6f2affe7dac75629e80fb1aa7708e466f02a4a10de4ab1422941b0a860c27a54/Files/Windows/System32/), though I don't know how many of the DLLs we should move or if the `mongo:*nanoserver` images are really even used.

```console
d????????? ?/?               0 ????-??-?? ??:?? ..
---------- 0/0           24440 2022-01-05 15:34 msvcp140_1.dll
---------- 0/0           56184 2022-01-05 15:34 msvcp140_atomic_wait.dll
---------- 0/0          316848 2022-01-05 15:34 concrt140.dll
d--------- 0/0               0 2024-06-07 09:20 config
---------- 0/0          571824 2022-01-05 15:34 msvcp140.dll
---------- 0/0           57872 2024-06-12 18:06 FNTCACHE.DAT
---------- 0/0          187304 2022-01-05 15:34 msvcp140_2.dll
d--------- 0/0               0 2024-06-07 16:03 Microsoft
---------- 0/0           20344 2022-01-05 15:34 msvcp140_codecvt_ids.dll
---------- 0/0          336304 2022-01-05 15:34 vccorlib140.dll
---------- 0/0           97656 2022-01-05 15:34 vcruntime140.dll
---------- 0/0           37240 2022-01-05 15:34 vcruntime140_1.dll
d--------- 0/0               0 2021-05-08 08:27 winevt
d--------- 0/0               0 2024-06-07 09:05 LogFiles
```