### PR TITLE
Update `versions.sh` to filter targets correctly for pre-releases

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -80,10 +80,10 @@ ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR {{ if env.version != env.rcVersion then "testing" else env.version end }}
 RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb.asc ] http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR {{ if target.image | test("^debian") then "main" else "multiverse" end }}" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
-{{ if env.version != env.rcVersion and (env.rcVersion | tonumber >= 5) then ( -}}
-{{ if .version | ltrimstr(env.rcVersion) | startswith(".0-") then ( -}}
+{{ if env.version != env.rcVersion then ( -}}
+{{ if .dockerNeedsVersion then ( -}}
 # {{ env.rcVersion }} is not GA, so we need the previous release for mongodb-mongosh and mongodb-database-tools
-RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb.asc ] http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/{{ env.rcVersion | split(".") | .[0] |= (tonumber - 1 | tostring) | join(".") }} {{ if target.image | test("^debian") then "main" else "multiverse" end }}" | tee "/etc/apt/sources.list.d/mongodb-previous.list"
+RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb.asc ] http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/{{ .dockerNeedsVersion }} {{ if target.image | test("^debian") then "main" else "multiverse" end }}" | tee "/etc/apt/sources.list.d/mongodb-previous.list"
 {{ ) else ( -}}
 # add GA repo for mongodb-mongosh and mongodb-database-tools
 RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb.asc ] http://$MONGO_REPO/apt/{{ target.image | gsub(":.*$"; "") }} {{ target.suite }}/${MONGO_PACKAGE%-unstable}/{{ env.rcVersion }} {{ if target.image | test("^debian") then "main" else "multiverse" end }}" | tee "/etc/apt/sources.list.d/mongodb-{{ env.rcVersion }}.list"

--- a/versions.json
+++ b/versions.json
@@ -197,6 +197,7 @@
   "8.0-rc": {
     "changes": "https://jira.mongodb.org/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%228.0.0-rc13%22%20ORDER%20BY%20status%20DESC%2C%20priority%20DESC",
     "date": "07/11/2024",
+    "dockerNeedsVersion": "7.0",
     "githash": "b5271455825d4af9af540e3dd05ae19963355efb",
     "linux": "ubuntu2204",
     "notes": "https://docs.mongodb.org/master/release-notes/8.0/",


### PR DESCRIPTION
This is relevant right now because 8.0.0-rc15 adds support for ubuntu 24.04 (noble), but 7.0 doesn't support it yet, so it's impossible to install the `noble` pre-release builds.

This fixes the calculation of which base image to use by cross-referencing this case.  While doing so, I centralized more of the logic for when/where we need that backwards version so we don't have to do the same weird calculations in multiple places / languages (with a new `dockerNeedsVersion` field in `versions.json`).

With this change, I was able to run `./versions.sh` and successfully build 8.0.0-rc15.