### PR TITLE
replace gosu by setpriv

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -38,16 +36,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -71,9 +59,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -38,16 +36,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -71,9 +59,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/7.0-rc/Dockerfile
+++ b/7.0-rc/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -38,16 +36,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -71,9 +59,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/7.0-rc/docker-entrypoint.sh
+++ b/7.0-rc/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -38,16 +36,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -71,9 +59,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -23,8 +23,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -38,16 +36,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -71,9 +59,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -18,8 +18,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-# grab gosu for easy step-down from root (https://github.com/tianon/gosu/releases)
-ENV GOSU_VERSION 1.17
 # grab "js-yaml" for parsing mongod's YAML config files (https://github.com/nodeca/js-yaml/releases)
 ENV JSYAML_VERSION 3.13.1
 ENV JSYAML_CHECKSUM 662e32319bdd378e91f67578e56a34954b0a2e33aca11d70ab9f4826af24b941
@@ -33,16 +31,6 @@ RUN set -eux; \
 		wget \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
-	\
-# download/install gosu
-	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-	gpgconf --kill all; \
-	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 # download/install js-yaml
 	mkdir -p /opt/js-yaml/; \
@@ -66,9 +54,8 @@ RUN set -eux; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
 # smoke test
-	chmod +x /usr/local/bin/gosu; \
-	gosu --version; \
-	gosu nobody true
+	setpriv --version \
+	setpriv --reuid nobody --regid nogroup --clear-groups true
 
 RUN mkdir /docker-entrypoint-initdb.d
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ "$originalArgOne" == mongo* ]] && [ "$(id -u)" = '0' ]; then
 	chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
 	# ignore errors thanks to https://github.com/docker-library/mongo/issues/149
 
-	exec gosu mongodb "$BASH_SOURCE" "$@"
+	exec setpriv --reuid mongodb --regid mongodb --clear-groups "$BASH_SOURCE" "$@"
 fi
 
 dpkgArch="$(dpkg --print-architecture)"


### PR DESCRIPTION
Replace gosu by setpriv, which is already installed in ubuntu base image since focal.
Gets rid of all the false positive vulnerabilitie scans from gosu.

Docker image: https://hub.docker.com/r/weberu/mongo