### PR TITLE
Enable tcmalloc per-cpu caches

### DIFF
--- a/8.0-rc/Dockerfile
+++ b/8.0-rc/Dockerfile
@@ -116,6 +116,10 @@ VOLUME /data/db /data/configdb
 # https://github.com/docker-library/mongo/issues/524
 ENV HOME /data/db
 
+# ensure that glibc isn't using rseq so that google-tcmalloc can
+# https://www.mongodb.com/docs/manual/administration/tcmalloc-performance/#disable-glibc-rseq
+ENV GLIBC_TUNABLES glibc.pthread.rseq=0
+
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -114,6 +114,10 @@ VOLUME /data/db /data/configdb
 # https://github.com/docker-library/mongo/issues/524
 ENV HOME /data/db
 
+# ensure that glibc isn't using rseq so that google-tcmalloc can
+# https://www.mongodb.com/docs/manual/administration/tcmalloc-performance/#disable-glibc-rseq
+ENV GLIBC_TUNABLES glibc.pthread.rseq=0
+
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -119,6 +119,13 @@ VOLUME /data/db /data/configdb
 # ensure that if running as custom user that "mongosh" has a valid "HOME"
 # https://github.com/docker-library/mongo/issues/524
 ENV HOME /data/db
+{{ if (env.rcVersion | tonumber >= 8) then ( -}}
+{{ # TODO remove this when it is no longer necessary: https://www.mongodb.com/docs/manual/administration/tcmalloc-performance/#enable-per-cpu-caches -}}
+
+# ensure that glibc isn't using rseq so that google-tcmalloc can
+# https://www.mongodb.com/docs/manual/administration/tcmalloc-performance/#disable-glibc-rseq
+ENV GLIBC_TUNABLES glibc.pthread.rseq=0
+{{ ) else "" end -}}
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
Enable tcmalloc per-cpu caches by disabling glibc rseq (following the [MongoDB docs](https://www.mongodb.com/docs/manual/administration/tcmalloc-performance/)). Users will still need to meet the other requirements listed there (like kernel version and transparent hugepages enabled).

Fixes https://github.com/docker-library/mongo/discussions/722

Current behavior, logged warning on startup and per-CPU cache disabled:
```console
$ docker run --name mongo mongo:8.0
...
{"t":{"$date":"2025-03-14T17:56:33.977+00:00"},"s":"W",  "c":"CONTROL",  "id":8718500, "ctx":"initandlisten","msg":"Your system has glibc support for rseq built in, which is not yet supported by tcmalloc-google and has critical performance implications. Please set the environment variable GLIBC_TUNABLES=glibc.pthread.rseq=0","tags":["startupWarnings"]}
...
$ docker exec -it mongo mongosh --eval 'db.runCommand( { serverStatus: 0, tcmalloc: 1 } ).tcmalloc.usingPerCPUCaches'
false
```

Results, no more warning on startup and per-CPU cache is enabled: 
```console
$ docker run --name mongo mongo:8.0-test
...
$ docker exec -it mongo mongosh --eval 'db.runCommand( { serverStatus: 0, tcmalloc: 1 } ).tcmalloc.usingPerCPUCaches'
true
```

Not sure when google-tcmalloc will be compatible with glibc rseq (https://github.com/google/tcmalloc/issues/144), but then MongoDB would have to use that new version, so it might be a while before this can be removed.