### PR TITLE
Install mongosh to Windows images

### DIFF
--- a/7.0/windows/nanoserver-ltsc2022/Dockerfile
+++ b/7.0/windows/nanoserver-ltsc2022/Dockerfile
@@ -25,7 +25,55 @@ COPY --from=mongo:7.0.28-windowsservercore-ltsc2022 \
 ENV MONGO_VERSION 7.0.28
 # 12/16/2025, https://github.com/mongodb/mongo/tree/cfc346c59d2cc3dbc903507fc642e22e3097f362
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 COPY --from=mongo:7.0.28-windowsservercore-ltsc2022 C:\\mongodb C:\\mongodb
+
+# Install mongosh on nanoserver too (explicitly invoke powershell)
+RUN powershell -NoProfile -Command "$ErrorActionPreference='Stop'; \
+	$Headers=@{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api=('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release=Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset=$Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host 'MSI asset has no digest field to verify.'; \
+		exit 1; \
+	}; \
+	$Digest=[string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha=$Matches[1].ToLowerInvariant(); \
+	$MongoshName=[string]$Asset.name; \
+	$MongoshUrl=[string]$Asset.browser_download_url; \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha=(Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('SHA256 mismatch: expected={0} actual={1}' -f $ExpectedSha,$ActualSha); \
+		exit 1;\
+	}; \
+	Start-Process msiexec -Wait -ArgumentList @('/i',$MongoshName,'/quiet','/qn','/l*v','mongosh-install.log'); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		Write-Host 'mongosh install may have failed.'; \
+		exit 1; \
+	}; \
+	mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force;"
+
 RUN mongod --version
 
 VOLUME C:\\data\\db C:\\data\\configdb

--- a/7.0/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/7.0/windows/windowsservercore-ltsc2022/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 7.0.28
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=1b771743b269dde79eeef4fedd133b988b84dff343429c8b5bf1b158e0fbb3bf
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/7.0/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/7.0/windows/windowsservercore-ltsc2025/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 7.0.28
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-7.0.28-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=1b771743b269dde79eeef4fedd133b988b84dff343429c8b5bf1b158e0fbb3bf
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/8.0/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8.0/windows/nanoserver-ltsc2022/Dockerfile
@@ -25,7 +25,55 @@ COPY --from=mongo:8.0.17-windowsservercore-ltsc2022 \
 ENV MONGO_VERSION 8.0.17
 # 12/16/2025, https://github.com/mongodb/mongo/tree/b20e43625b72f4bb43cc15107f80ac966ae13b6d
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 COPY --from=mongo:8.0.17-windowsservercore-ltsc2022 C:\\mongodb C:\\mongodb
+
+# Install mongosh on nanoserver too (explicitly invoke powershell)
+RUN powershell -NoProfile -Command "$ErrorActionPreference='Stop'; \
+	$Headers=@{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api=('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release=Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset=$Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host 'MSI asset has no digest field to verify.'; \
+		exit 1; \
+	}; \
+	$Digest=[string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha=$Matches[1].ToLowerInvariant(); \
+	$MongoshName=[string]$Asset.name; \
+	$MongoshUrl=[string]$Asset.browser_download_url; \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha=(Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('SHA256 mismatch: expected={0} actual={1}' -f $ExpectedSha,$ActualSha); \
+		exit 1;\
+	}; \
+	Start-Process msiexec -Wait -ArgumentList @('/i',$MongoshName,'/quiet','/qn','/l*v','mongosh-install.log'); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		Write-Host 'mongosh install may have failed.'; \
+		exit 1; \
+	}; \
+	mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force;"
+
 RUN mongod --version
 
 VOLUME C:\\data\\db C:\\data\\configdb

--- a/8.0/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8.0/windows/windowsservercore-ltsc2022/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 8.0.17
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.0.17-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=4481f5af2795a6a1d74f22bcb5f0e52eeead96ac993a45ccbc50107e4a38b489
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/8.0/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8.0/windows/windowsservercore-ltsc2025/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 8.0.17
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.0.17-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=4481f5af2795a6a1d74f22bcb5f0e52eeead96ac993a45ccbc50107e4a38b489
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/8.2/windows/nanoserver-ltsc2022/Dockerfile
+++ b/8.2/windows/nanoserver-ltsc2022/Dockerfile
@@ -25,7 +25,55 @@ COPY --from=mongo:8.2.3-windowsservercore-ltsc2022 \
 ENV MONGO_VERSION 8.2.3
 # 12/15/2025, https://github.com/mongodb/mongo/tree/36f41c9c30a2f13f834d033ba03c3463c891fb01
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 COPY --from=mongo:8.2.3-windowsservercore-ltsc2022 C:\\mongodb C:\\mongodb
+
+# Install mongosh on nanoserver too (explicitly invoke powershell)
+RUN powershell -NoProfile -Command "$ErrorActionPreference='Stop'; \
+	$Headers=@{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api=('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release=Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset=$Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host 'MSI asset has no digest field to verify.'; \
+		exit 1; \
+	}; \
+	$Digest=[string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha=$Matches[1].ToLowerInvariant(); \
+	$MongoshName=[string]$Asset.name; \
+	$MongoshUrl=[string]$Asset.browser_download_url; \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha=(Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('SHA256 mismatch: expected={0} actual={1}' -f $ExpectedSha,$ActualSha); \
+		exit 1;\
+	}; \
+	Start-Process msiexec -Wait -ArgumentList @('/i',$MongoshName,'/quiet','/qn','/l*v','mongosh-install.log'); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		Write-Host 'mongosh install may have failed.'; \
+		exit 1; \
+	}; \
+	mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force;"
+
 RUN mongod --version
 
 VOLUME C:\\data\\db C:\\data\\configdb

--- a/8.2/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/8.2/windows/windowsservercore-ltsc2022/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 8.2.3
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.2.3-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=dbad91532fd5f5bb5b42818ce7a644dd603a388926303b306e23ef29a640e849
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/8.2/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/8.2/windows/windowsservercore-ltsc2025/Dockerfile
@@ -15,6 +15,8 @@ ENV MONGO_VERSION 8.2.3
 ENV MONGO_DOWNLOAD_URL https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-8.2.3-signed.msi
 ENV MONGO_DOWNLOAD_SHA256=dbad91532fd5f5bb5b42818ce7a644dd603a388926303b306e23ef29a640e849
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -52,6 +54,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	\
 	Write-Host 'Verifying install ...'; \
 	Write-Host '  mongod --version'; mongod --version; \
+	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \

--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -18,6 +18,8 @@ ENV MONGO_VERSION {{ .version }}
 ENV MONGO_DOWNLOAD_URL {{ .targets.windows.msi }}
 ENV MONGO_DOWNLOAD_SHA256={{ .targets.windows.sha256 }}
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	(New-Object System.Net.WebClient).DownloadFile($env:MONGO_DOWNLOAD_URL, 'mongo.msi'); \
@@ -59,6 +61,66 @@ RUN Write-Host ('Downloading {0} ...' -f $env:MONGO_DOWNLOAD_URL); \
 {{ ) else "" end -}}
 	Write-Host '  mongod --version'; mongod --version; \
 	\
+	# -------------------------------
+	# Install mongosh (latest MSI) + sha256 verification from GitHub asset digest
+	# https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
+	# -------------------------------
+	Write-Host 'Installing mongosh (latest release) ...'; \
+	$Headers = @{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api = ('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release = Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset = $Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host ('MSI asset has no digest field to verify.'); \
+		exit 1; \
+	}; \
+	$Digest = [string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha = $Matches[1].ToLowerInvariant(); \
+	$MongoshName = [string]$Asset.name; \
+	$MongoshUrl  = [string]$Asset.browser_download_url; \
+	Write-Host ('Downloading {0} ...' -f $MongoshUrl); \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha = (Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	Write-Host ('Verifying mongosh sha256 ({0}) ...' -f $ExpectedSha); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('FAILED! expected={0} actual={1}' -f $ExpectedSha, $ActualSha); \
+		exit 1; \
+	}; \
+	Write-Host 'Installing mongosh ...'; \
+	Start-Process msiexec -Wait \
+		-ArgumentList @( \
+			'/i', \
+			$MongoshName, \
+			'/quiet', \
+			'/qn', \
+			'/l*v', \
+			'mongosh-install.log' \
+		); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		Write-Host 'mongosh install may have failed!'; \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		exit 1; \
+	}; \
+	Write-Host '  mongosh --version'; mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force; \
+	# -------------------------------
+	\
 	Write-Host 'Removing ...'; \
 	Remove-Item C:\windows\installer\*.msi -Force; \
 	Remove-Item mongo.msi -Force; \
@@ -91,7 +153,55 @@ ENV MONGO_VERSION {{ .version }}
 # {{ [ .date // empty, "https://github.com/mongodb/mongo/tree/" + .githash // empty ] | join(", ") }}
 {{ ) else "" end -}}
 
+ENV MONGOSH_REPO=mongodb-js/mongosh
+
 COPY --from={{ copy_from }} C:\\mongodb C:\\mongodb
+
+# Install mongosh on nanoserver too (explicitly invoke powershell)
+RUN powershell -NoProfile -Command "$ErrorActionPreference='Stop'; \
+	$Headers=@{ \
+		'Accept'='application/vnd.github+json'; \
+		'User-Agent'='PowerShell-Mongosh-Installer' \
+	}; \
+	$Api=('https://api.github.com/repos/{0}/releases/latest' -f $env:MONGOSH_REPO); \
+	$Release=Invoke-RestMethod -Uri $Api -Headers $Headers -Method Get; \
+	$Asset=$Release.assets | Where-Object { $_.content_type -eq 'application/x-msi' } | Select-Object -First 1; \
+	if (-not $Asset) { \
+		Write-Host ('No MSI asset found in latest release for {0}' -f $env:MONGOSH_REPO); \
+		exit 1; \
+	}; \
+	if (-not $Asset.digest) { \
+		Write-Host 'MSI asset has no digest field to verify.'; \
+		exit 1; \
+	}; \
+	$Digest=[string]$Asset.digest; \
+	if ($Digest -notmatch '^sha256:([0-9a-fA-F]{64})$') { \
+		Write-Host ('Unexpected digest format: {0}' -f $Digest); \
+		exit 1; \
+	}; \
+	$ExpectedSha=$Matches[1].ToLowerInvariant(); \
+	$MongoshName=[string]$Asset.name; \
+	$MongoshUrl=[string]$Asset.browser_download_url; \
+	Invoke-WebRequest -Uri $MongoshUrl -Headers $Headers -OutFile $MongoshName; \
+	$ActualSha=(Get-FileHash -Path $MongoshName -Algorithm SHA256).Hash.ToLowerInvariant(); \
+	if ($ActualSha -ne $ExpectedSha) { \
+		Write-Host ('SHA256 mismatch: expected={0} actual={1}' -f $ExpectedSha,$ActualSha); \
+		exit 1;\
+	}; \
+	Start-Process msiexec -Wait -ArgumentList @('/i',$MongoshName,'/quiet','/qn','/l*v','mongosh-install.log'); \
+	if (-Not (Get-Command mongosh -ErrorAction SilentlyContinue)) { \
+		if (Test-Path mongosh-install.log) { \
+			Get-Content mongosh-install.log; \
+		}; \
+		Write-Host 'mongosh install may have failed.'; \
+		exit 1; \
+	}; \
+	mongosh --version; \
+	if (Test-Path mongosh-install.log) { \
+		Remove-Item mongosh-install.log -Force; \
+	}; \
+	Remove-Item $MongoshName -Force;"
+
 RUN {{ if has_client then ( }}mongo --version && {{ ) else "" end }}mongod --version
 {{ ) end -}}
 


### PR DESCRIPTION
Related to #708.

This installs `mongosh` on Windows images, since it is not installed by default with `mongodb`.

## References

- https://www.mongodb.com/docs/mongodb-shell/install/?operating-system=windows&windows-installation-method=msiexec
- Mongosh releases now have a sha256 associated to the artifacts: https://github.com/mongodb-js/mongosh/releases/tag/v2.6.0.