### PR TITLE
Fix jq comment line continuation in versions.sh

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -22,7 +22,7 @@ shell="$(
 							"windows.*" # windows, windows_x86_64, windows_x86_64-2012plus, etc
 						] | join("|")) + ")$")
 						and (
-							# a few things old enough we do not want anything to do with them /o\
+							# a few things old enough we do not want anything to do with them /o\.
 							test("^(" + ([
 								"debian[89].*",
 								"ubuntu1[0-9].*"


### PR DESCRIPTION
./versions.sh was failing with:
```
jq: error: syntax error, unexpected INVALID_CHARACTER, expecting '|' or ',' or ')' at <top-level>, line 24, column 8
```

Keep the `/o\` flourish in the jq comment, but avoid ending the line with a bare backslash so jq does not treat the next line as a continuation.